### PR TITLE
Add support for ShowDevelopmentTools

### DIFF
--- a/appshell/cefclient.cpp
+++ b/appshell/cefclient.cpp
@@ -156,6 +156,9 @@ void AppGetSettings(CefSettings& settings, CefRefPtr<ClientApp> app) {
     // Provide a ClientApp instance to handle proxy resolution.
     app->SetProxyConfig(proxy_type, proxy_config);
   }
+    
+  // Enable dev tools
+  settings.remote_debugging_port = 9234;
 }
 
 // Returns the application browser settings based on command line arguments.

--- a/appshell/client_app.cpp
+++ b/appshell/client_app.cpp
@@ -144,7 +144,7 @@ class AppShellExtensionHandler : public CefV8Handler {
                        const CefV8ValueList& arguments,
                        CefRefPtr<CefV8Value>& retval,
                        CefString& exception) {
-
+      
       // The only message that is handled here is getElapsedMilliseconds(). All other
       // messages are passed to the browser process.
       if (name == "GetElapsedMilliseconds") {
@@ -152,22 +152,24 @@ class AppShellExtensionHandler : public CefV8Handler {
       } else {
           // Pass all messages to the browser process. Look in appshell_extensions.cpp for implementation.
           CefRefPtr<CefBrowser> browser = 
-          CefV8Context::GetCurrentContext()->GetBrowser();
+                CefV8Context::GetCurrentContext()->GetBrowser();
           ASSERT(browser.get());
           CefRefPtr<CefProcessMessage> message = 
                 CefProcessMessage::Create(name);
           CefRefPtr<CefListValue> messageArgs = message->GetArgumentList();
           
           // The first argument must be a callback function
-          if (arguments.size() < 1 || !arguments[0]->IsFunction()) {
+          if (arguments.size() > 0 && !arguments[0]->IsFunction()) {
               std::string functionName = name;
               fprintf(stderr, "Function called without callback param: %s\n", functionName.c_str());
               return false;
           } 
           
-          // The first argument is the message id
-          client_app_->AddCallback(messageId, CefV8Context::GetCurrentContext(), arguments[0]);
-          SetListValue(messageArgs, 0, CefV8Value::CreateInt(messageId));
+          if (arguments.size() > 0) {
+              // The first argument is the message id
+              client_app_->AddCallback(messageId, CefV8Context::GetCurrentContext(), arguments[0]);
+              SetListValue(messageArgs, 0, CefV8Value::CreateInt(messageId));
+          }
           
           // Pass the rest of the arguments
           for (unsigned int i = 1; i < arguments.size(); i++)

--- a/appshell/client_handler.cpp
+++ b/appshell/client_handler.cpp
@@ -14,7 +14,6 @@
 #include "string_util.h"
 #include "appshell/appshell_extensions.h"
 
-
 // Custom menu command Ids.
 enum client_menu_ids {
   CLIENT_ID_SHOW_DEVTOOLS   = MENU_ID_USER_FIRST,
@@ -290,6 +289,13 @@ void ClientHandler::ShowDevTools(CefRefPtr<CefBrowser> browser) {
     browser->GetMainFrame()->ExecuteJavaScript(
         "window.open('" +  devtools_url + "');", "about:blank", 0);
   }
+}
+
+bool ClientHandler::OnBeforeUnloadDialog(CefRefPtr<CefBrowser> browser,
+                                  const CefString& message_text,
+                                  bool is_reload,
+                                  CefRefPtr<CefJSDialogCallback> callback) {
+    return false;
 }
 
 // static

--- a/appshell/client_handler.h
+++ b/appshell/client_handler.h
@@ -25,7 +25,8 @@ class ClientHandler : public CefClient,
                       public CefRequestHandler,
                       public CefDisplayHandler,
                       public CefGeolocationHandler,
-                      public CefContextMenuHandler {
+                      public CefContextMenuHandler,
+                      public CefJSDialogHandler {
  public:
   // Interface for process message delegates. Do not perform work in the
   // RenderDelegate constructor.
@@ -85,6 +86,10 @@ class ClientHandler : public CefClient,
   virtual CefRefPtr<CefContextMenuHandler> GetContextMenuHandler() OVERRIDE {
     return this;
   }
+  virtual CefRefPtr<CefJSDialogHandler> GetJSDialogHandler() OVERRIDE {
+    return this;
+  }
+                          
   virtual bool OnProcessMessageRecieved(CefRefPtr<CefBrowser> browser,
                                         CefProcessId source_process,
                                         CefRefPtr<CefProcessMessage> message)
@@ -180,6 +185,12 @@ class ClientHandler : public CefClient,
 
   void ShowDevTools(CefRefPtr<CefBrowser> browser);
 
+  // CefJSDialogHandler methods
+  virtual bool OnBeforeUnloadDialog(CefRefPtr<CefBrowser> browser,
+                                    const CefString& message_text,
+                                    bool is_reload,
+                                    CefRefPtr<CefJSDialogCallback> callback);
+                          
  protected:
   void SetLoading(bool isLoading);
   void SetNavState(bool canGoBack, bool canGoForward);
@@ -217,7 +228,7 @@ class ClientHandler : public CefClient,
   CefWindowHandle m_ForwardHwnd;
   CefWindowHandle m_StopHwnd;
   CefWindowHandle m_ReloadHwnd;
-
+                          
   // Support for logging.
   std::string m_LogFile;
 


### PR DESCRIPTION
This pull request implements the ShowDevelopmentTools native function. Implementing this required changes to the plug-in message passing - you can now pass messages without a callback, as long as the message does not have any parameters.

This request also includes a stubbed out version of the onbeforeunload handler. This will be used to catch window closing once window.close() is fixed in CEF.
