### PR TITLE
Win-only: destroy first browser in map last

### DIFF
--- a/appshell/client_handler.cpp
+++ b/appshell/client_handler.cpp
@@ -106,16 +106,7 @@ bool ClientHandler::DoClose(CefRefPtr<CefBrowser> browser) {
 void ClientHandler::OnBeforeClose(CefRefPtr<CefBrowser> browser) {
   REQUIRE_UI_THREAD();
 
-#if defined(OS_WIN)
-  // The main browser is the first in the map. It needs to be destroyed last.
-  // So, if we're the main browser, don't erase browser from the map until
-  // there's only 1 browser remaining in the list. Windows-only.
-  CefWindowHandle hWndThis = browser->GetHost()->GetWindowHandle();
-  CefWindowHandle hWndMain = browser_window_map_.begin()->first;
-
-  if (browser_window_map_.size() == 1 || hWndMain != hWndThis)
-#endif
-  {
+  if (CanCloseBrowser(browser)) {
     if (m_BrowserId == browser->GetIdentifier()) {
       // Free the browser pointer so that the browser can be destroyed
       m_Browser = NULL;

--- a/appshell/client_handler.h
+++ b/appshell/client_handler.h
@@ -162,6 +162,7 @@ class ClientHandler : public CefClient,
 
   CefRefPtr<CefBrowser> GetBrowser() { return m_Browser; }
   int GetBrowserId() { return m_BrowserId; }
+  bool CanCloseBrowser(CefRefPtr<CefBrowser> browser);
 
   std::string GetLogFile();
 

--- a/appshell/client_handler_gtk.cpp
+++ b/appshell/client_handler_gtk.cpp
@@ -69,3 +69,7 @@ void ClientHandler::SetNavState(bool canGoBack, bool canGoForward) {
 void ClientHandler::CloseMainWindow() {
   // TODO(port): Close main window.
 }
+
+bool ClientHandler::CanCloseBrowser(CefRefPtr<CefBrowser> browser) {
+	return true;
+}

--- a/appshell/client_handler_mac.mm
+++ b/appshell/client_handler_mac.mm
@@ -223,3 +223,7 @@ CefRefPtr<CefBrowser> ClientHandler::GetBrowserForNativeWindow(void* window) {
   }
   return browser;
 }
+
+bool ClientHandler::CanCloseBrowser(CefRefPtr<CefBrowser> browser) {
+  return true;
+}

--- a/appshell/client_handler_win.cpp
+++ b/appshell/client_handler_win.cpp
@@ -221,3 +221,18 @@ CefRefPtr<CefBrowser> ClientHandler::GetBrowserForNativeWindow(void* window) {
   }
   return browser;
 }
+
+bool ClientHandler::CanCloseBrowser(CefRefPtr<CefBrowser> browser) {
+
+  // On windows, the main browser is the first in the map. It needs to be
+  // destroyed last. So, don't allow main browser to be closed until there's
+  // only 1 browser remaining in the map.
+  if (browser_window_map_.size() > 1) {
+    CefWindowHandle hWndBrowser = browser->GetHost()->GetWindowHandle();
+    CefWindowHandle hWndMain    = browser_window_map_.begin()->first;
+
+    return (hWndBrowser != hWndMain);
+  }
+
+  return true;
+}


### PR DESCRIPTION
On Windows, the main browser is the first in the map. It needs to be destroyed last. So, if we're the main browser, don't erase browser from the map until there's only 1 browser remaining in the list.

This code causes problems on Mac, so it has been isolated for Windows-only.

Brackets-shell issue #17.
