### PR TITLE
disable show dev tools V8 extension

### DIFF
--- a/appshell/appshell_extensions.js
+++ b/appshell/appshell_extensions.js
@@ -193,10 +193,14 @@ if (!appshell.app) {
     /**
      * Invokes developer tools application
      */
+    // FIXME (jason-sanjose): https://github.com/adobe/brackets-shell/issues/16
+    // Disable "Show Developer Tools" in brackets-shell. Debug from Chrome via http://localhost:9234
+    /*
     native function ShowDeveloperTools();
     appshell.app.showDeveloperTools = function () {
         ShowDeveloperTools();
     };
+    */
 
     /**
      * Reads the entire contents of a file. 


### PR DESCRIPTION
Remove `appshell.app.showDeveloperTools`. JavaScript detection already implemented to disable this feature when `showDeveloperTools` is undefined. This only impacts brackets-shell. brackets-app is unaffected.
