### PR TITLE
Update GYP file to work with Xcode 4.4

### DIFF
--- a/appshell.gyp
+++ b/appshell.gyp
@@ -5,7 +5,6 @@
 {
   'variables': {
     'appname': 'Brackets',
-    'mac_sdk': '10.6',
     'chromium_code': 1,
     'conditions': [
       [ 'OS=="mac"', {
@@ -18,6 +17,15 @@
     # Bring in the source file lists for appshell.
     'appshell_paths.gypi',
   ],
+  'target_defaults':
+  {
+    'xcode_settings':
+      {
+        'SDKROOT': '',
+        'CLANG_CXX_LANGUAGE_STANDARD' : 'c++0x',
+        'COMBINE_HIDPI_IMAGES': 'YES',
+      },
+  },
   'targets': [
     {
       'target_name': '<(appname)',
@@ -56,7 +64,6 @@
         'SYMROOT': 'xcodebuild',
         'GCC_TREAT_WARNINGS_AS_ERRORS': 'NO',
         'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0',
-        'CLANG_CXX_LANGUAGE_STANDARD' : 'c++0x',
       },
       'conditions': [
         ['OS=="win"', {
@@ -201,7 +208,6 @@
         'SYMROOT': 'xcodebuild',
         'GCC_TREAT_WARNINGS_AS_ERRORS': 'NO',
         'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0',
-        'CLANG_CXX_LANGUAGE_STANDARD' : 'c++0x',
       },
     },
   ],
@@ -252,7 +258,6 @@
             'SYMROOT': 'xcodebuild',
             'GCC_TREAT_WARNINGS_AS_ERRORS': 'NO',
             'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0',
-            'CLANG_CXX_LANGUAGE_STANDARD' : 'c++0x',
           },
           'postbuilds': [
             {

--- a/appshell.xcodeproj/project.pbxproj
+++ b/appshell.xcodeproj/project.pbxproj
@@ -1372,6 +1372,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				GCC_CW_ASM_SYNTAX = NO;
 				GCC_C_LANGUAGE_STANDARD = c99;
@@ -1434,6 +1435,7 @@
 					"-Wl,-pie",
 				);
 				PRODUCT_NAME = Brackets;
+				SDKROOT = "";
 				SHARED_PRECOMPS_DIR = "$(CONFIGURATION_BUILD_DIR)/SharedPrecompiledHeaders";
 				SYMROOT = xcodebuild;
 				USE_HEADERMAP = NO;
@@ -1463,6 +1465,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				EXECUTABLE_PREFIX = lib;
 				GCC_CW_ASM_SYNTAX = NO;
@@ -1513,6 +1516,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.5;
 				OTHER_CFLAGS = "-fno-strict-aliasing";
 				PRODUCT_NAME = cef_dll_wrapper;
+				SDKROOT = "";
 				SHARED_PRECOMPS_DIR = "$(CONFIGURATION_BUILD_DIR)/SharedPrecompiledHeaders";
 				SYMROOT = xcodebuild;
 				USE_HEADERMAP = NO;
@@ -1538,6 +1542,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				GCC_CW_ASM_SYNTAX = NO;
 				GCC_C_LANGUAGE_STANDARD = c99;
@@ -1600,6 +1605,7 @@
 					"-Wl,-pie",
 				);
 				PRODUCT_NAME = "Brackets Helper";
+				SDKROOT = "";
 				SHARED_PRECOMPS_DIR = "$(CONFIGURATION_BUILD_DIR)/SharedPrecompiledHeaders";
 				SYMROOT = xcodebuild;
 				USE_HEADERMAP = NO;
@@ -1619,6 +1625,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				GCC_CW_ASM_SYNTAX = NO;
 				GCC_C_LANGUAGE_STANDARD = c99;
@@ -1683,6 +1690,7 @@
 					"-Wl,-pie",
 				);
 				PRODUCT_NAME = Brackets;
+				SDKROOT = "";
 				SHARED_PRECOMPS_DIR = "$(CONFIGURATION_BUILD_DIR)/SharedPrecompiledHeaders";
 				SYMROOT = xcodebuild;
 				USE_HEADERMAP = NO;
@@ -1712,6 +1720,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				GCC_CW_ASM_SYNTAX = NO;
 				GCC_C_LANGUAGE_STANDARD = c99;
@@ -1776,6 +1785,7 @@
 					"-Wl,-pie",
 				);
 				PRODUCT_NAME = "Brackets Helper";
+				SDKROOT = "";
 				SHARED_PRECOMPS_DIR = "$(CONFIGURATION_BUILD_DIR)/SharedPrecompiledHeaders";
 				SYMROOT = xcodebuild;
 				USE_HEADERMAP = NO;
@@ -1802,6 +1812,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				EXECUTABLE_PREFIX = lib;
 				GCC_CW_ASM_SYNTAX = NO;
@@ -1854,6 +1865,7 @@
 					"-fstack-protector-all",
 				);
 				PRODUCT_NAME = cef_dll_wrapper;
+				SDKROOT = "";
 				SHARED_PRECOMPS_DIR = "$(CONFIGURATION_BUILD_DIR)/SharedPrecompiledHeaders";
 				SYMROOT = xcodebuild;
 				USE_HEADERMAP = NO;


### PR DESCRIPTION
- Reverse engineered Xcode settings from @jdiehl in #46 to update appshell.gyp
- Committed clean copy of appshell.xcodeproj as generated by gyp

Fixes issues #47 and #48.

Need to sanity check other OSX and Xcode versions. I've tested OSX 10.7 Lion with Xcode 4.4. If this works, we should skip pull request #46.
