### PR TITLE
Fix build on xcode < 4.2

### DIFF
--- a/appshell/cefclient_mac.mm
+++ b/appshell/cefclient_mac.mm
@@ -288,7 +288,7 @@ NSButton* MakeButton(NSRect* rect, NSString* title, NSView* parent) {
                        defer:NO];
   [mainWnd setTitle:@"Brackets"];
   [mainWnd setDelegate:delegate];
-  [mainWnd setCollectionBehavior: NSWindowCollectionBehaviorFullScreenPrimary];
+  [mainWnd setCollectionBehavior: (1 << 7) /* NSWindowCollectionBehaviorFullScreenPrimary */];
 
   // Rely on the window delegate to clean us up rather than immediately
   // releasing when the window gets closed. We use the delegate to do

--- a/appshell/client_handler_mac.mm
+++ b/appshell/client_handler_mac.mm
@@ -200,7 +200,7 @@ void ClientHandler::CloseMainWindow() {
 
 void ClientHandler::PopupCreated(CefRefPtr<CefBrowser> browser) {
   NSWindow* window = [browser->GetHost()->GetWindowHandle() window];
-  [window setCollectionBehavior: NSWindowCollectionBehaviorFullScreenPrimary];
+  [window setCollectionBehavior: (1 << 7) /* NSWindowCollectionBehaviorFullScreenPrimary */];
   
   if (![window delegate]) {
     PopupClientWindowDelegate* delegate = [[PopupClientWindowDelegate alloc] init];


### PR DESCRIPTION
The NSWindowCollectionBahaviorFullScreenPrimary constant is only available in 10.7 or later SDK. To work around this, use the value instead: (1 << 7). 

If we end up adding any more Lion-specific functionality, we may want to up our build requirements to XCode 4.2...
