### PR TITLE
add abortQuit callback to notify all browsers of abort quit

### DIFF
--- a/appshell/client_handler.cpp
+++ b/appshell/client_handler.cpp
@@ -359,6 +359,19 @@ void ClientHandler::DispatchCloseToNextBrowser() {
   }
 }
 
+void ClientHandler::AbortQuit()
+{
+	m_quitting = false;
+
+	// Notify all browsers that quit was aborted
+	BrowserWindowMap::const_iterator i, last = browser_window_map_.end();
+	for (i = browser_window_map_.begin(); i != last; i++)
+	{
+		CefRefPtr<CefBrowser> browser = i->second;
+		SendJSCommand(browser, APP_ABORT_QUIT);
+	}
+}
+
 // static
 void ClientHandler::CreateProcessMessageDelegates(
       ProcessMessageDelegateSet& delegates) {

--- a/appshell/client_handler.h
+++ b/appshell/client_handler.h
@@ -186,7 +186,7 @@ class ClientHandler : public CefClient,
   void SendJSCommand(CefRefPtr<CefBrowser> browser, const CefString& command, CefRefPtr<CommandCallback> callback = NULL);
   
   void DispatchCloseToNextBrowser();
-  void AbortQuit() {m_quitting = false;}
+  void AbortQuit();
   static CefRefPtr<CefBrowser> GetBrowserForNativeWindow(void* window);
 
   void QuittingApp(bool quitting) { m_quitting = quitting; }

--- a/appshell/command_callbacks.h
+++ b/appshell/command_callbacks.h
@@ -5,9 +5,10 @@
 
 // Command names. These MUST be in sync with the command names in
 // brackets/src/command/Commands.js
-const std::string FILE_QUIT = "file.quit";
+const std::string APP_ABORT_QUIT    = "app.abort_quit";
+const std::string FILE_QUIT         = "file.quit";
 const std::string FILE_CLOSE_WINDOW = "file.close_window";
-const std::string HELP_ABOUT = "help.about";
+const std::string HELP_ABOUT        = "help.about";
 
 // Base CommandCallback class
 class CommandCallback : public CefBase {


### PR DESCRIPTION
This is for brackets-shell issue #42.

This needs to be merged with this brackets pull request:
https://github.com/adobe/brackets/pull/1344
