### PR TITLE
Make sure submodules are updated during build

### DIFF
--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -21,6 +21,7 @@ curDir=`pwd`
 cd $BRACKETS_SRC
 git checkout $branchName
 git pull origin $branchName
+git submodule update --init
 cd $curDir
 git checkout $branchName
 git pull origin $branchName


### PR DESCRIPTION
Call `git submodule update --init` after pulling new code. This is only done on the brackets repo, since brackets-shell doesn't have any submodules.
