### PR TITLE
Mac build script: do recursive submodule update/init

### DIFF
--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -21,7 +21,7 @@ curDir=`pwd`
 cd $BRACKETS_SRC
 git checkout $branchName
 git pull origin $branchName
-git submodule update --init
+git submodule update --init --recursive
 cd $curDir
 git checkout $branchName
 git pull origin $branchName


### PR DESCRIPTION
We don't have any recursive submodules in brackets yet, but just in case we do add any in the future, the build script will now handle it.
