### PR TITLE
Add VERSIONINFO resource

### DIFF
--- a/appshell/cefclient.rc
+++ b/appshell/cefclient.rc
@@ -25,6 +25,44 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 
 /////////////////////////////////////////////////////////////////////////////
 //
+// VersionInfo
+//
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION    	0,13,0,0
+/* PRODUCTVERSION 	1,0,0,0 */
+FILEOS         	VOS__WINDOWS32
+FILETYPE       	VFT_APP
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904E4"
+        BEGIN
+            VALUE "CompanyName",      "brackets.io\0"
+            VALUE "FileDescription",  "\0"
+            VALUE "FileVersion",      "Sprint 13\0"
+            VALUE "ProductName",      "Brackets\0"
+            VALUE "ProductVersion",   "\0"
+            VALUE "LegalCopyright",   "(c) 2012 Adobe Systems, Inc.\0"
+        END
+    END
+
+    BLOCK "VarFileInfo"
+    BEGIN
+        /* The following line should only be modified for localized versions.     */
+        /* It consists of any number of WORD,WORD pairs, with each pair           */
+        /* describing a language,codepage combination supported by the file.      */
+        /*                                                                        */
+        /* For example, a file might have values "0x409,1252" indicating that it  */
+        /* supports English language (0x409) in the Windows ANSI codepage (1252). */
+
+        VALUE "Translation", 0x409, 1252
+        VALUE "Translation", 0x40C, 1252
+    END
+END
+
+/////////////////////////////////////////////////////////////////////////////
+//
 // Binary
 //
 


### PR DESCRIPTION
This is a Windows resource that is used to populate the "Details" tab in the Brackets.exe properties dialog, and to display file version information in the Add/Remove Programs control panel.
