### PR TITLE
Disable log file by default

### DIFF
--- a/appshell/cefclient.cpp
+++ b/appshell/cefclient.cpp
@@ -81,7 +81,10 @@ void AppGetSettings(CefSettings& settings, CefRefPtr<ClientApp> app) {
 
   {
     std::string str = g_command_line->GetSwitchValue(cefclient::kLogSeverity);
-    bool invalid = false;
+
+    // Default to LOGSEVERITY_DISABLE
+    settings.log_severity = LOGSEVERITY_DISABLE;
+
     if (!str.empty()) {
       if (str == cefclient::kLogSeverity_Verbose)
         settings.log_severity = LOGSEVERITY_VERBOSE;
@@ -95,14 +98,6 @@ void AppGetSettings(CefSettings& settings, CefRefPtr<ClientApp> app) {
         settings.log_severity = LOGSEVERITY_ERROR_REPORT;
       else if (str == cefclient::kLogSeverity_Disable)
         settings.log_severity = LOGSEVERITY_DISABLE;
-      else
-        invalid = true;
-    }
-    if (str.empty() || invalid) {
-#ifdef NDEBUG
-      // Only log error messages and higher in release build.
-      settings.log_severity = LOGSEVERITY_ERROR;
-#endif
     }
   }
 


### PR DESCRIPTION
Don't create a debug.log file by default. This can be overridden by specifying --log-severity on the command line.

This fixes issue adobe/brackets#1538
