### PR TITLE
Mac installer improvements

### DIFF
--- a/installer/mac/buildInstaller.sh
+++ b/installer/mac/buildInstaller.sh
@@ -13,6 +13,17 @@ rm -rf $tempDir
 mkdir $tempDir
 cp -r "./staging/${BRACKETS_APP_NAME}.app/" "$tempDir/$appName"
 
+# create symlink to Applications folder in staging area
+# with a single space as the name so it doesn't show an unlocalized name
+ln -s /Applications "$tempDir/ "
+
+# copy volume icon to staging area if one exists
+customIcon=""
+if [ -f ./assets/VolumeIcon.icns ]; then
+  cp ./assets/VolumeIcon.icns "$tempDir/.VolumeIcon.icns"
+  customIcon="--custom-icon"
+fi
+
 # create disk layout
 rm -rf $tempLayoutDir
 cp -r ./dropDmgConfig/layouts/bracketsLayout/ "$tmpLayout"
@@ -20,10 +31,9 @@ cp -r ./dropDmgConfig/layouts/bracketsLayout/ "$tmpLayout"
 # Replace APPLICATION_NAME in Info.plist with $releaseName.app
 grep -rl APPLICATION_NAME "${tmpLayout}/Info.plist" | xargs sed -i -e "s/APPLICATION_NAME/${releaseName}.app/g"
 
-
 # build the DMG
 echo "building DMG..."
-dropdmg ./$tempDir --format $format --encryption $encryption --layout-folder "$tmpLayout" --volume-name "$releaseName" --base-name "$releaseName"
+dropdmg ./$tempDir --format $format --encryption $encryption $customIcon --layout-folder "$tmpLayout" --volume-name "$releaseName" --base-name "$releaseName"
 
 # clean up
 rm -rf $tempDir

--- a/installer/mac/dropDmgConfig/layouts/bracketsLayout/Info.plist
+++ b/installer/mac/dropDmgConfig/layouts/bracketsLayout/Info.plist
@@ -20,11 +20,11 @@
 					<key>identifier</key>
 					<string>LayoutItem.41ACEC13-5995-48E6-A3F1-6C766090B2BF</string>
 					<key>name</key>
-					<string>Applications</string>
+					<string> </string>
 					<key>position</key>
 					<string>{327, 148}</string>
 					<key>type</key>
-					<string>applications</string>
+					<string> </string>
 				</dict>
 				<dict>
 					<key>identifier</key>


### PR DESCRIPTION
- Remove name from Applications shortcut so it doesn't need to be localized. (The shortcut still shows the Applications folder icon.)
- Add ability to override the volume icon.
