### PR TITLE
Fix index.hmtl lookup

### DIFF
--- a/appshell/cefclient_win.cpp
+++ b/appshell/cefclient_win.cpp
@@ -106,10 +106,15 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
     // Get the full pathname for the app. We look for the index.html
     // file relative to this location.
     wchar_t appPath[MAX_PATH];
+    wchar_t *pathRoot;
     GetModuleFileName(NULL, appPath, MAX_PATH);
 
+    // Strip the .exe filename (and preceding "\") from the appPath
+    // and store in pathRoot
+    pathRoot = wcsrchr(appPath, '\\');
+
     // Look for .\dev\src\index.html first
-    wcscpy(wcsrchr(appPath, '\\'), L"\\dev\\src\\index.html");
+    wcscpy(pathRoot, L"\\dev\\src\\index.html");
 
     // If the file exists, use it
     if (GetFileAttributes(appPath) != INVALID_FILE_ATTRIBUTES) {
@@ -118,7 +123,7 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
 
     if (!wcslen(szInitialUrl)) {
       // Look for .\www\index.html next
-      wcscpy(wcsrchr(appPath, '\\'), L"\\www\\index.html");
+      wcscpy(pathRoot, L"\\www\\index.html");
       if (GetFileAttributes(appPath) != INVALID_FILE_ATTRIBUTES) {
         wcscpy(szInitialUrl, appPath);
       }


### PR DESCRIPTION
Fixes a bug from commit 5df27ce91

When looking for the index.html file, we start with the module pathname (the full path of the .exe file), strip off "\Brackets.exe" and append a relative string like "\dev\src\index.html". If we don't find the file in the first location (`.\dev\src\index.html`), we were _not_ resetting the app pathname, so the second lookup was looking in `.\dev\src\www\index.html` instead of `.\www\index.html`.
