### PR TITLE
Temporarily remove 'launch Brackets' checkbox from installer

### DIFF
--- a/installer/win/Brackets.wxs
+++ b/installer/win/Brackets.wxs
@@ -48,14 +48,14 @@ xmlns:fire="http://schemas.microsoft.com/wix/FirewallExtension">
 
 
     <!-- Launch app after install -->
-
+<!--
     <Property Id="LAUNCHAPPONEXIT" Value="1" />
     <Property Id="WixShellExecTarget" Value="[#fil7EE01D0693DA0F92C26C5F3007D1BF2C]" />
     <CustomAction Id="LaunchApplication" FileKey="fil7EE01D0693DA0F92C26C5F3007D1BF2C" ExeCommand="" Execute="immediate" Impersonate="yes" Return="asyncNoWait" />
-    
+-->
     <UI>
       <Publish Dialog="MyExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
-      <Publish Dialog="MyExitDialog" Control="Finish" Order="1" Event="DoAction" Value="LaunchApplication">LAUNCHAPPONEXIT=1 and NOT INSTALLED AND NOT REMOVE="ALL"</Publish>
+      <!--<Publish Dialog="MyExitDialog" Control="Finish" Order="1" Event="DoAction" Value="LaunchApplication">LAUNCHAPPONEXIT=1 and NOT INSTALLED AND NOT REMOVE="ALL"</Publish>-->
 
     </UI>
 

--- a/installer/win/ExitDialog.wxs
+++ b/installer/win/ExitDialog.wxs
@@ -36,10 +36,11 @@
                 <Control Id="TitleInstall" Hidden="yes" Type="Text" X="15" Y="15" Width="350" Height="15" Transparent="yes" NoPrefix="yes" Text="!(loc.ExitDialogTitleInstall)" >
                     <Condition Action="show">NOT Installed</Condition>
                 </Control>
-
+                <!--
                 <Control Id="LaunchCheckBox" Type="CheckBox" X="10" Y="243" Width="270" Height="17" Property="LAUNCHAPPONEXIT" Hidden="yes" CheckBoxValue="1" Text=" !(loc.ExitDialogLaunchApp)">
                     <Condition Action="show">NOT Installed</Condition>
                 </Control>
+                -->
             </Dialog>
 
             <InstallUISequence>


### PR DESCRIPTION
Temporarily remove the 'launch Brackets' checkbox from the installer UI until we can fix bug #1473
