### PR TITLE
Add script to inject build number, branch and SHA on Windows.

### DIFF
--- a/installer/win/set_build_number.py
+++ b/installer/win/set_build_number.py
@@ -1,0 +1,46 @@
+﻿# This script sets the build number, branch name and SHA in the 
+# staged package.json file.
+#
+# This script is called by the stageForInstaller script.
+#
+# The following environment variables MUST be set:
+#  STAGED_SRC - path to the www directory in the staging folder
+#  BUILD_NUM - Build number to write into package.json file
+#  BUILD_BRANCH - Name of branch to write into package.json file
+#  BUILD_SHA - SHA to write into package.json file
+#
+# If any of these variables are empty, this script writes a warning message
+# and exits
+
+import os
+import re
+import shutil
+
+# Check for environment variables
+staged_src = os.getenv("STAGED_SRC")
+build_num = os.getenv("BUILD_NUM")
+build_branch = os.getenv("BUILD_BRANCH")
+build_sha = os.getenv("BUILD_SHA")
+
+if (not staged_src) or (not build_num) or (not build_branch) or (not build_sha):
+    print("One or more environment variables was not set.")
+    print("Please make sure STAGED_SRC, BUILD_NUM, BUILD_BRANCH, and BUILD_SHA are all set.")
+    exit()
+
+staged_filename = staged_src + "/package.json"
+tmp_filename = "build_number.tmp"
+
+tmp_file = open(tmp_filename , "w");
+pkg_file = open(staged_filename , "r")
+
+for line in pkg_file:
+    line = re.sub(r'("version"[^"]*"[0-9.]*-)([0-9]*)(")', r'\g<1>'+build_num+'\g<3>', line);
+    line = re.sub(r'("branch"[^"]*")([^"]*)(")', r'\g<1>'+build_branch+'\g<3>', line);
+    line = re.sub(r'("SHA"[^"]*")([^"]*)(")', r'\g<1>'+build_sha+'\g<3>', line);
+    tmp_file.write(line);
+
+pkg_file.close();
+tmp_file.close();
+
+# Finally, move the tmp file back to staging
+shutil.move(tmp_filename, staged_filename)

--- a/installer/win/stageForInstaller.bat
+++ b/installer/win/stageForInstaller.bat
@@ -98,7 +98,35 @@ echo Copying sample content from %BRACKETS_SRC%\samples ...
 
 xcopy %BRACKETS_SRC%\samples staging\samples /s /i
 
+:: Update the build number, branch and SHA in the staged package.json file.
+:: The python script depends on several environment variables. Set them here.
+set cur_dir=%cd%
+cd %BRACKETS_SRC%
 
+:: Get build number. This is the number of git log entries on the current branch.
+git log --oneline | find /c " " > staging.tmp
+set /p BUILD_NUM=< staging.tmp
+del staging.tmp
+
+:: Get branch.
+git status | find /n " " | find "[1]" > staging.tmp
+set /p BUILD_BRANCH=< staging.tmp
+del staging.tmp
+:: variable has "[1]#On branch" at the beginning; strip it off
+set BUILD_BRANCH=%BUILD_BRANCH:[1]# On branch =%
+
+:: Get the build SHA. This is from the first line in the git log
+git log | find /n " " | find "[1]" > staging.tmp
+set /p BUILD_SHA=< staging.tmp
+del staging.tmp
+:: variable has "[1]commit " at the beginning; strip it off
+set BUILD_SHA=%BUILD_SHA:[1]commit =%
+
+set STAGED_SRC=staging\www
+
+:: Call the python script to inject the build number, branch name and SHA into package.json
+cd %cur_dir%
+python set_build_number.py
 
 echo.
 echo Done staging Brackets for Windows! (Run installer generator script next)


### PR DESCRIPTION
The Windows `stageForInstaller.bat` script now extracts the build number, branch and SHA, and calls a new `set_build_number.py` script that injects the information into the staged `package.json` file.

**Note:** the stageForInstaller script now requires python to run. This should be okay because python is already required to build our gyp files.

The script also needs to have git installed for command line use. I'm pretty sure this happens by default when you install the chrome developer tools (that's how I got python and git on the command line), so this shouldn't be an issue either.
