### PR TITLE
Don't update settings.locale with our detected locale from OS.

### DIFF
--- a/appshell/cefclient.cpp
+++ b/appshell/cefclient.cpp
@@ -101,7 +101,10 @@ void AppGetSettings(CefSettings& settings, CefRefPtr<ClientApp> app) {
     }
   }
 
-  CefString(&settings.locale) = app->GetCurrentLanguage();
+  // Don't update the settings.locale with the locale that we detected from the OS.
+  // Otherwise, CEF will use it to find the resources and when it fails in finding resources
+  // for some locales that are not available in resources, it crashes.
+  //CefString(&settings.locale) = app->GetCurrentLanguage( );
 
   CefString(&settings.javascript_flags) =
       g_command_line->GetSwitchValue(cefclient::kJavascriptFlags);

--- a/appshell/client_app_mac.mm
+++ b/appshell/client_app_mac.mm
@@ -50,17 +50,6 @@ CefString ClientApp::GetCurrentLanguage()
   
     NSString* language = [[NSLocale preferredLanguages] objectAtIndex:0];
     
-    // Remap zh-Hans --> zh-CN and zh-Hant --> zh-TW so that CEF3 can find the corresponding localized resources.
-    // We may need to remove these two lines in the future if CEF3 switches to the newer locale names.
-    language = [language stringByReplacingOccurrencesOfString:@"Hans" withString:@"CN"];
-    language = [language stringByReplacingOccurrencesOfString:@"Hant" withString:@"TW"];
-    
-    // Remap pt --> pt-BR so that we can load the CEF3 resource for Brazilian Portuguese.
-    // [rlim] I believe this is the last one that we have to remap. If we find any to reamp again,
-    // then we should just switch to CFLocaleCopyPreferredLanguages() instead of [[NSLocale preferredLanguages].
-    if ([language isEqualToString:@"pt"])
-         language = [language stringByReplacingOccurrencesOfString:@"pt" withString:@"pt-BR"];
-    
     CefString result = [language UTF8String];
     return result;
 }


### PR DESCRIPTION
Also remove the mappings that we put in before to fix crashes for Chinese OSes and Brazilian Portuguese.

I did try with CFLocaleCopyPreferredLanguages() and it returns the same locale ID as our  current code [[NSLocale preferredLanguages] objectAtIndex:0]. So we can't use it either.

This fixes issue [#1716](https://github.com/adobe/brackets/issues/1716)
