### PR TITLE
Disable console.log writing

### DIFF
--- a/appshell/client_handler.cpp
+++ b/appshell/client_handler.cpp
@@ -189,6 +189,11 @@ bool ClientHandler::OnConsoleMessage(CefRefPtr<CefBrowser> browser,
                                      const CefString& message,
                                      const CefString& source,
                                      int line) {
+  // Don't write the message to a console.log file. Instead, we'll just
+  // return false here so the message gets written to the console (output window
+  // in xcode, or console window in dev tools)
+  
+/*
   REQUIRE_UI_THREAD();
 
   bool first_message;
@@ -224,7 +229,7 @@ bool ClientHandler::OnConsoleMessage(CefRefPtr<CefBrowser> browser,
     if (first_message)
       SendNotification(NOTIFY_CONSOLE_MESSAGE);
   }
-
+*/
   return false;
 }
 


### PR DESCRIPTION
CEF 3.1180.823 enabled console logging, which by default, is written to a console.log file. 

We don't want this in Brackets. Console messages are displayed in the xcode output window (when running from xcode) or the Dev Tools console window, so the console.log file is not needed.

Fixes adobe/brackets#1842
