### PR TITLE
Check for file exists before renaming

### DIFF
--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -356,6 +356,13 @@ int32 Rename(ExtensionString oldName, ExtensionString newName)
     NSString* oldPathStr = [NSString stringWithUTF8String:oldName.c_str()];
     NSString* newPathStr = [NSString stringWithUTF8String:newName.c_str()];
   
+    // Check to make sure newName doesn't already exist. On OS 10.7 and later, moveItemAtPath
+    // returns a nice "NSFileWriteFileExists" error in this case, but 10.6 returns a generic
+    // "can't write" error.
+    if ([[NSFileManager defaultManager] fileExistsAtPath:newPathStr]) {
+        return ERR_FILE_EXISTS;
+    }
+  
     [[NSFileManager defaultManager] moveItemAtPath:oldPathStr toPath:newPathStr error:&error];
   
     return ConvertNSErrorCode(error, false);


### PR DESCRIPTION
@redmunds

Fix for adobe/brackets#1876

On OSX 10.6, `moveItemAtPath` does not give a nice error if the destination name already exists, so we now do an early check to see if the file exists _before_ calling rename.
