### PR TITLE
Possible fix for #1473 (Uninstaller doesn't always remove Brackets start menu shortcut)

### DIFF
--- a/installer/win/Brackets.wxs
+++ b/installer/win/Brackets.wxs
@@ -32,7 +32,7 @@ xmlns:fire="http://schemas.microsoft.com/wix/FirewallExtension">
     </DirectoryRef>
 
     <DirectoryRef Id="ProgramMenuFolder">
-      <Component Id="StartMenuShortcut" Guid="{C90B75F4-7E02-43A9-9A2C-FC1A251349EC}" Win64="no" >
+      <Component Id="StartMenuShortcut" Guid="{3C6EAEA9-C8EB-49A4-91EF-5D9E8037FAF6}" Win64="no" >
         <Shortcut Id="AppShortcut" Name="!(loc.ProductName) $(var.ProductVersionName)"
                  Description="!(loc.ShortcutDescription)"
                  Target="[INSTALLDIR]\$(var.ExeName).exe" />


### PR DESCRIPTION
Possible fix for bug adobe/brackets#1473: use a different GUID for StartMenuShortcut from previous sprints, which should disentangle the Component ref counts and allow uninstalling the two shortcuts independently.

This fix was suggested by @RajNarayana, and I've found some other [small references to this](http://stackoverflow.com/questions/5866954/wix-project-allowing-side-by-side-installation#comment6781442_5869087) as well.  I did a brief test and it appears to fix the problem on the build machine when there are side-by-side installs.

I don't think we should _actually_ close 1473 right away, though -- given how inconsistently reproducible it's been, we should wait until Sprint 16 ends and we can verify this more broadly on various different computers.  At that point we can also consider whether to automate the GUID changing or just add it to the sprint checklist.
