### PR TITLE
Return file names in composed canonical UTF-8 form

### DIFF
--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -478,7 +478,7 @@ int32 DeleteFileOrDirectory(ExtensionString filename)
 void NSArrayToCefList(NSArray* array, CefRefPtr<CefListValue>& list)
 {
     for (NSUInteger i = 0; i < [array count]; i++) {
-        list->SetString(i, [[array objectAtIndex:i] UTF8String]);
+        list->SetString(i, [[[array objectAtIndex:i] precomposedStringWithCanonicalMapping] UTF8String]);
     }
 }
 


### PR DESCRIPTION
Fixes adobe/brackets#1678. I did not find other places that report file names. The tests for FileIndexManager and LowLevelFileIO still pass.
