### PR TITLE
Skip all system files when reading a folder.

### DIFF
--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -525,8 +525,9 @@ int32 ReadDir(ExtensionString path, CefRefPtr<CefListValue>& directoryContents)
 
     if (hFind != INVALID_HANDLE_VALUE) {
         do {
-            // Ignore '.' and '..'
-            if (!wcscmp(ffd.cFileName, L".") || !wcscmp(ffd.cFileName, L".."))
+            // Ignore '.' and '..' and system files
+            if (!wcscmp(ffd.cFileName, L".") || !wcscmp(ffd.cFileName, L"..") ||
+                (ffd.dwFileAttributes & FILE_ATTRIBUTE_SYSTEM))
                 continue;
 
             // Collect file and directory names separately


### PR DESCRIPTION
This fixes issue [#1937](https://github.com/adobe/brackets/issues/1937).
