### PR TITLE
Add WINDOW_TITLE constant to config.h

### DIFF
--- a/appshell/cefclient_mac.mm
+++ b/appshell/cefclient_mac.mm
@@ -326,7 +326,7 @@ NSButton* MakeButton(NSRect* rect, NSString* title, NSView* parent) {
   content_rect = [mainWnd contentRectForFrameRect:[mainWnd frame]];
 
   // Configure the rest of the window
-  [mainWnd setTitle:APP_NAME];
+  [mainWnd setTitle:WINDOW_TITLE];
   [mainWnd setDelegate:delegate];
   [mainWnd setCollectionBehavior: (1 << 7) /* NSWindowCollectionBehaviorFullScreenPrimary */];
 

--- a/appshell/config.h
+++ b/appshell/config.h
@@ -30,12 +30,14 @@
 // This must be an empty string (for no group), or a string that ends with "\\"
 #define GROUP_NAME L""
 #define APP_NAME L"Brackets"
+#define WINDOW_TITLE APP_NAME
 #endif
 #ifdef OS_MACOSX
 // Name of group (if any) that application prefs/settings/etc. are stored under
 // This must be an empty string (for no group), or a string that ends with "/"
 #define GROUP_NAME @""
 #define APP_NAME @"Brackets"
+#define WINDOW_TITLE APP_NAME
 #endif
 
 


### PR DESCRIPTION
This allows the default window title to be different than the app name, if desired. For example, you may want to add the company name to the window title.
