### PR TITLE
route mac calls to terminate through the same paths as file quit

### DIFF
--- a/appshell/cefclient_mac.mm
+++ b/appshell/cefclient_mac.mm
@@ -426,7 +426,7 @@ NSButton* MakeButton(NSRect* rect, NSString* title, NSView* parent) {
 }
 
 - (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication *)theApplication {
-    if (!g_isTerminating && g_handler.get() && !g_handler->AppIsQuitting()) {
+    if (!g_isTerminating && g_handler.get() && !g_handler->AppIsQuitting() && g_handler->HasWindows()) {
         g_handler->DispatchCloseToNextBrowser();
         return NSTerminateCancel;
     }

--- a/appshell/client_handler.h
+++ b/appshell/client_handler.h
@@ -191,6 +191,7 @@ class ClientHandler : public CefClient,
 
   void QuittingApp(bool quitting) { m_quitting = quitting; }
   bool AppIsQuitting() { return m_quitting; }
+  bool HasWindows() const { return !browser_window_map_.empty(); }
 
  protected:
   void SetLoading(bool isLoading);


### PR DESCRIPTION
This fixes a potential loss of data where quitting the mac using the quit menu on dock context menu wouldn't check for unchanged files. Steps to reproduce:
- Open a file in brackets
- make some changes so the file is dirty
- go to the icon in the mac dock, right click and select quit

Original Result:
Brackets quits and changes are lost

New Result:
Brackets prompts for save, don't save, cancel before quiting. 
