### PR TITLE
Fix for #2245 Use app->GetCurrentLanguage()

### DIFF
--- a/appshell/cefclient_win.cpp
+++ b/appshell/cefclient_win.cpp
@@ -183,7 +183,6 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
 
   // Temporary localization hack. Default to English. Check for French.
   DWORD menuId = IDC_CEFCLIENT;
-  std::string lang = app->GetCurrentLanguage().ToString();
   if (app->GetCurrentLanguage() == CefString("fr-FR"))
   {
 	  menuId = IDC_CEFCLIENT_FR;


### PR DESCRIPTION
Use app->GetCurrentLanguage() instead of previous settings.locale for reading the system locale

Fix for adobe/brackets#2245
