### PR TITLE
add chmod command to mac make_symlinks.sh so that tools scripts are executable

### DIFF
--- a/scripts/make_symlinks.sh
+++ b/scripts/make_symlinks.sh
@@ -8,3 +8,6 @@ ln -s deps/cef/libcef_dll/ libcef_dll
 ln -s deps/cef/Release/ Release
 ln -s deps/cef/Resources/ Resources
 ln -s deps/cef/tools/ tools
+
+# Make sure scripts in deps/cef/tools are executable
+chmod u+x deps/cef/tools/*


### PR DESCRIPTION
@gruehle 

On the mac, the scripts that get symlinked from the CEF distribution into the 'tools' directory are not executable by default. (If the distribution is unziped with 'unzip' at the command line, anyway.) This causes the build to fail in xcode because it won't execute post-build scripts that don't have the executable bit set.

This pull adds a line at the end of the symlink creation script to make all the files executable by the current user. Admittedly, this makes the make_symlinks.sh filename a bit of a misnomer. Changing it to something like 'mac_bootstrap_cef.sh' might make more sense?
