### PR TITLE
Fix for compiling on Mac 10.6

### DIFF
--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -527,9 +527,11 @@ int32 ConvertNSErrorCode(NSError* error, bool isReading)
         case NSFileWriteOutOfSpaceError:
             return ERR_OUT_OF_SPACE;
             break;
+#if 1070 <= MAC_OS_X_VERSION_MAX_ALLOWED
         case NSFileWriteFileExistsError:
             return ERR_FILE_EXISTS;
             break;
+#endif
     }
     
     // Unknown error


### PR DESCRIPTION
I have a fix for compiling on 10.6. For as simple as the changes are I probably have to release them as public domain since I haven't signed the CLA.
