### PR TITLE
Fix a bug when you try to use readdir with empty string.

### DIFF
--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -332,7 +332,7 @@ int32 ReadDir(ExtensionString path, CefRefPtr<CefListValue>& directoryContents)
     NSError* error = nil;
     
     if ([pathStr length] == 0) {
-      return ERR_INVALID_PARAMS;
+        return ERR_INVALID_PARAMS;
     }
 
     NSArray* contents = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:pathStr error:&error];


### PR DESCRIPTION
To test:

```
appshell.fs.readdir('', function(err, paths) { console.log(err) })
```

The end result is an unresponsive application.  This hasn't been tested with the windows version.

Again, since I haven't signed the CLA, this code is released un public domain.
