### PR TITLE
Avoid build script data loss on XP

### DIFF
--- a/scripts/make_symlinks.bat
+++ b/scripts/make_symlinks.bat
@@ -1,3 +1,11 @@
+ECHO OFF
+
+REM - Check for OS. This script works in Vista or later.
+REM   Running it on XP may delete the entire Brackets repo if 'Release\dev' is a junction point.
+ver | findstr /i "5\.1\." > nul
+IF %ERRORLEVEL% EQU 0 GOTO XPNotSupported
+
+
 REM Remove existing links
 rmdir Debug include lib libcef_dll Release
 
@@ -8,4 +16,12 @@ mklink /j lib deps\cef\lib
 mklink /j libcef_dll deps\cef\libcef_dll
 mklink /j Release deps\cef\Release
 
-exit
+GOTO Exit
+
+
+:XPNotSupported
+ECHO Sorry, this script doesn't run in Windows XP. Build brackets-shell on a newer computer and
+ECHO manually place the results in brackets-shell\Release.
+
+
+:Exit


### PR DESCRIPTION
@gruehle for review

make_symlinks.bat is unsafe on XP, since 'rmdir Release' is likely to delete the entire brackets repo if 'Release' exists at all (because the only type of 'symlink' available on XP, for use with Release\dev, works that way).

Hoping this wouldn't bite anyone else anyway, but just in case... (since it definitely sucks to have it happen)

This change makes the script refuse to run on XP instead of doing the dangerous rmdir, similar to the code in setup_for_hacking.bat.
