### PR TITLE
Add bash bang to several shell scripts

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # SETUP - MAC
 # - Install xcode
 # - Install xcode command line tools 

--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # IMPORTANT: THIS FILE WILL BE GOING AWAY SOON! USE scripts/build.sh INSTEAD! 
 # YOU HAVE BEEN WARNED!
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,2 +1,4 @@
+#!/bin/bash
+
 scripts/download_deps.sh
 scripts/make_appshell_project.sh


### PR DESCRIPTION
Adds `#!/bin/bash` to the top of a few shell scripts that didn't have it.

I was having crazy errors running setup.sh from bash on Mac OS X 10.8.2 without this. Adding this fixed it. For example:

```
-bash(455) malloc: *** error for object 0x800007f84c2c0002: pointer being freed was not allocated
*** set a breakpoint in malloc_error_break to debug
Abort trap: 6
```
