### PR TITLE
always recreate projects in build.sh after checking out code

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -64,6 +64,9 @@ else
     echo "Skipping fetch for brackets-shell repo"
 fi
 
+# Rebuild project files after potentially checking out new code
+scripts/make_appshell_project.sh
+
 os=${OSTYPE//[0-9.]/}
 
 if [ "$os" = "darwin" ]; then # Building on mac


### PR DESCRIPTION
@gruehle The build.sh script possibly checks out a different branch/SHA than the user is currently on. Different SHAs could have different files in the project. So, the project files need to be rebuilt after a checkout.

This forces project recreation right before the compile step.
