### PR TITLE
add "Brackets" to user agent string, and move remote debugging port to config.h

### DIFF
--- a/appshell/cefclient.cpp
+++ b/appshell/cefclient.cpp
@@ -17,6 +17,7 @@
 #include "client_switches.h"
 #include "string_util.h"
 #include "util.h"
+#include "config.h"
 
 CefRefPtr<ClientHandler> g_handler;
 CefRefPtr<CefCommandLine> g_command_line;
@@ -123,7 +124,11 @@ void AppGetSettings(CefSettings& settings, CefRefPtr<ClientApp> app) {
   }
     
   // Enable dev tools
-  settings.remote_debugging_port = 9234;
+  settings.remote_debugging_port = REMOTE_DEBUGGING_PORT;
+  
+  // Set product version, which gets added to the User Agent string
+  CefString(&settings.product_version) = PRODUCT_VERSION_STRING;
+
 }
 
 // Returns the application browser settings based on command line arguments.

--- a/appshell/config.h
+++ b/appshell/config.h
@@ -40,6 +40,17 @@
 #define WINDOW_TITLE APP_NAME
 #endif
 
+// Product version string that gets added to the end of the user agent
+// TODO: Ideally, this would include a version number in addition to the
+// product name (something like "Brackets/0.18.0"). But, we don't currently
+// have a good cross-platform way to get appshell version numbers into
+// the build process. Once we do, we should change this.
+// Filed as bug #2442
+#ifndef PRODUCT_VERSION_STRING
+#define PRODUCT_VERSION_STRING "Brackets"
+#endif
+
+#define REMOTE_DEBUGGING_PORT 9234
 
 // Un-comment this line to show the toolbar UI at the top of the appshell window
 // #define SHOW_TOOLBAR_UI


### PR DESCRIPTION
Fix for adobe/brackets#2213

Modifies the user agent string to include "Brackets". The user agent string now looks like:

```
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.1 (KHTML, like Gecko) Brackets Safari/537.1
```

Ultimately, we probably want to add the build number to the user agent string as well (so it looks something like `... Brackets/0.18.0 ...`). However, this will require some changes to the build process because we'll need to figure out a way to have the build number available at compile time. This is discussed in more detail in issue adobe/brackets#2442.

Also moves the hard-coded remote debugging port to a #define in config.h. By having it in config.h, we can set separate ports for Brackets and Edge Code. This means that we can debug both of them at the same time without having to worry about which one we opened first.
