### PR TITLE
Remove dev symlinks before deleting Release or Debug dirs

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -88,10 +88,10 @@ if [ "$os" = "darwin" ]; then # Building on mac
 elif [ "$os" = "msys" ]; then # Building on Windows
 
     # Clean and build the Visual Studio project
-    cmd /k "scripts\build_projects.bat"
+    cmd.exe /c "scripts\build_projects.bat"
 
     # Stage files for installer
-    cmd /k "scripts\stage_for_installer.bat"
+    cmd.exe /c "scripts\stage_for_installer.bat"
 
     packageLocation="installer/win/staging/www"
 

--- a/scripts/build_projects.bat
+++ b/scripts/build_projects.bat
@@ -4,4 +4,4 @@
 call "%VS100COMNTOOLS%/vsvars32.bat"
 msbuild.exe appshell.sln /t:Clean /p:Platform=Win32 /p:Configuration=Release
 msbuild.exe appshell.sln /t:Build /p:Platform=Win32 /p:Configuration=Release
-exit
+exit /b

--- a/scripts/download_deps.sh
+++ b/scripts/download_deps.sh
@@ -46,7 +46,7 @@ else
     pushd "$root_dir"
     if [ "$os" = "msys" ]; then
         # Call batch file to make directory junctions
-        cmd /k "scripts\make_symlinks.bat"
+        cmd.exe /c "scripts\make_symlinks.bat"
     else
         rm Debug include libcef_dll Release Resources tools
         

--- a/scripts/make_symlinks.bat
+++ b/scripts/make_symlinks.bat
@@ -28,3 +28,4 @@ ECHO manually place the results in brackets-shell\Release.
 
 
 :Exit
+exit /b

--- a/scripts/stage_for_installer.bat
+++ b/scripts/stage_for_installer.bat
@@ -4,4 +4,4 @@
 cd installer/win
 call stageForInstaller.bat
 cd ../..
-exit
+exit /b


### PR DESCRIPTION
@redmunds @peterflynn 

Fix a data deletion error in the following scenario:
1. Setup/build brackets-shell on Windows
2. Run the `setup_for_hacking` script, passing the `Release` or `Debug` directory from step 1
3. Run the `scripts/make_symlinks.bat` script, either explicitly, or implicitly by running `scripts/setup.sh` when CEF needs to be downloaded.

Results: the contents of the symlinked `dev` directory are deleted.

To work around this, explicitly remove the symlinks to `dev` before removing the `Release` and `Debug` directories. 
