### PR TITLE
Package www files after copying the app to the staging directory

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -76,9 +76,6 @@ if [ "$os" = "darwin" ]; then # Building on mac
     xcodebuild -project appshell.xcodeproj -config Release clean
     xcodebuild -project appshell.xcodeproj -config Release build
     
-    # Package www files
-    scripts/package_www_files.sh
-    
     # Remove existing staging dir
     if [ -d installer/mac/staging ]; then
       rm -rf installer/mac/staging
@@ -88,6 +85,10 @@ if [ "$os" = "darwin" ]; then # Building on mac
     
     # Copy to installer staging folder
     cp -R "xcodebuild/Release/${BRACKETS_APP_NAME}.app" installer/mac/staging/
+     
+    # Package www files
+    scripts/package_www_files.sh
+
     packageLocation="installer/mac/staging/${BRACKETS_APP_NAME}.app/Contents/www"
 
 elif [ "$os" = "msys" ]; then # Building on Windows

--- a/scripts/package_www_files.sh
+++ b/scripts/package_www_files.sh
@@ -7,23 +7,23 @@ if [ "$BRACKETS_SRC" = "" ]; then
 fi
 
 # Remove existing www directory contents
-if [ -d "xcodebuild/Release/${BRACKETS_APP_NAME}.app/Contents/www" ]; then
-  rm -rf "xcodebuild/Release/${BRACKETS_APP_NAME}.app/Contents/www"
+if [ -d "installer/mac/staging/${BRACKETS_APP_NAME}.app/Contents/www" ]; then
+  rm -rf "installer/mac/staging/${BRACKETS_APP_NAME}.app/Contents/www"
 fi
 
 # Remove existing samples directory contents
-if [ -d "xcodebuild/Release/${BRACKETS_APP_NAME}.app/Contents/samples" ]; then
-  rm -rf "xcodebuild/Release/${BRACKETS_APP_NAME}.app/Contents/samples"
+if [ -d "installer/mac/staging/${BRACKETS_APP_NAME}.app/Contents/samples" ]; then
+  rm -rf "installer/mac/staging/${BRACKETS_APP_NAME}.app/Contents/samples"
 fi
 
 # Make the ${BRACKETS_APP_NAME}.app/Contents/www directory
-mkdir "xcodebuild/Release/${BRACKETS_APP_NAME}.app/Contents/www"
+mkdir "installer/mac/staging/${BRACKETS_APP_NAME}.app/Contents/www"
 
 # Copy the source 
-cp -pR "${BRACKETS_SRC}"/src/* "xcodebuild/Release/${BRACKETS_APP_NAME}.app/Contents/www"
+cp -pR "${BRACKETS_SRC}"/src/* "installer/mac/staging/${BRACKETS_APP_NAME}.app/Contents/www"
 
 # Make the ${BRACKETS_APP_NAME}.app/Contents/samples directory
-mkdir "xcodebuild/Release/${BRACKETS_APP_NAME}.app/Contents/samples"
+mkdir "installer/mac/staging/${BRACKETS_APP_NAME}.app/Contents/samples"
 
 # Copy the source 
-cp -pR "${BRACKETS_SRC}"/samples/* "xcodebuild/Release/${BRACKETS_APP_NAME}.app/Contents/samples"
+cp -pR "${BRACKETS_SRC}"/samples/* "installer/mac/staging/${BRACKETS_APP_NAME}.app/Contents/samples"


### PR DESCRIPTION
Fix for adobe/brackets#2481

Mac only - package the www files after copying the app to the staging directory. This keeps the version in `xcodebuild/Release` clean, and is consistent with the Windows version.
