### PR TITLE
Redraw menu bar after removing item.

### DIFF
--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -1276,6 +1276,7 @@ int32 RemoveMenuItem(CefRefPtr<CefBrowser> browser, const ExtensionString& comma
     DeleteMenu(mainMenu, tag, MF_BYCOMMAND);
     NativeMenuModel::getInstance(getMenuParent(browser)).removeMenuItem(commandId);
     RemoveKeyFromAcceleratorTable(tag);
+    DrawMenuBar((HWND)getMenuParent(browser));
     return NO_ERROR;
 }
 


### PR DESCRIPTION
@redmunds 

Fixes the lingering "TEST" menu in the native menu unit tests.
