### PR TITLE
Don't report error if a relative ID is not found when inserting a menu or a menu item.

### DIFF
--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -623,7 +623,7 @@ int32 getNewMenuPosition(CefRefPtr<CefBrowser> browser, const ExtensionString& p
         errCode = GetMenuPosition(browser, relativeId, parentId, positionIdx);
 
         // If we don't find the relative ID, then don't report the error. 
-        // Instead, just make sure that we set postiionIdx to -1.
+        // Instead, just make sure that we set positionIdx to -1.
         if (errCode == ERR_NOT_FOUND) {
             errCode = NO_ERROR;
             positionIdx = -1;

--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -863,7 +863,7 @@ int32 getNewMenuPosition(CefRefPtr<CefBrowser> browser, const ExtensionString& p
         errCode = GetMenuPosition(browser, relativeId, parentId, positionIdx);
 
         // If we don't find the relative ID, then don't report the error. 
-        // Instead, just make sure that we set postiionIdx to kAppend.
+        // Instead, just make sure that we set positionIdx to kAppend.
         if (errCode == ERR_NOT_FOUND) {
             errCode = NO_ERROR;
             positionIdx = kAppend;


### PR DESCRIPTION
Also remove a local variable declaration that is override the passed in parameter.
