### PR TITLE
Add another position hack to let users to insert menu with "first" position on Mac.

### DIFF
--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -728,6 +728,13 @@ int32 AddMenu(CefRefPtr<CefBrowser> browser, ExtensionString itemTitle, Extensio
     
     NSInteger positionIdx = -1;
     int32 errCode = getNewMenuPosition(browser, nil, position, relativeId, positionIdx);
+
+    // Another position hack. If position is "first" we will change positionIdx to 1
+    // since we can't allow user to put anything before the Mac OS default application menu.
+    if (position.size() > 0 && position == "first" && positionIdx == 0) {
+        positionIdx = 1;
+    }
+    
     if (positionIdx > -1) {
         [[NSApp mainMenu] insertItem:testItem atIndex:positionIdx];
     } else {


### PR DESCRIPTION
We adjust the position after the very first one that we can't relocate.
