### PR TITLE
Min size for Brackets window

### DIFF
--- a/appshell/cefclient_mac.mm
+++ b/appshell/cefclient_mac.mm
@@ -367,7 +367,7 @@ NSButton* MakeButton(NSRect* rect, NSString* title, NSView* parent) {
   // during cleanup (ie, a window close from javascript).
   [mainWnd setReleasedWhenClosed:NO];
 
-  NSSize minSize = NSMakeSize (450, 300);
+  NSSize minSize = NSMakeSize (WINDOW_MIN_WIDTH, WINDOW_MIN_HEIGHT);
   [mainWnd setMinSize: minSize];
     
   NSView* contentView = [mainWnd contentView];

--- a/appshell/cefclient_win.cpp
+++ b/appshell/cefclient_win.cpp
@@ -826,8 +826,8 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam,
       // set the MINMAXINFO structure pointer
       LPMINMAXINFO lpMinMaxInfo;
       lpMinMaxInfo = (MINMAXINFO FAR *) lParam;
-      lpMinMaxInfo->ptMinTrackSize.x = 450;
-      lpMinMaxInfo->ptMinTrackSize.y = 300;
+      lpMinMaxInfo->ptMinTrackSize.x = WINDOW_MIN_WIDTH;
+      lpMinMaxInfo->ptMinTrackSize.y = WINDOW_MIN_HEIGHT;
       break;
 
     case WM_ERASEBKGND:

--- a/appshell/config.h
+++ b/appshell/config.h
@@ -50,6 +50,9 @@
 
 #endif
 
+#define WINDOW_MIN_WIDTH 450
+#define WINDOW_MIN_HEIGHT 300
+
 #define REMOTE_DEBUGGING_PORT 9234
 
 // Un-comment this line to show the toolbar UI at the top of the appshell window


### PR DESCRIPTION
Let's assume a minimum size of 450x300 for the Brackets window. If we go smaller, we hide most of the editor area.
