### PR TITLE
Open files with shared read perm on Windows

### DIFF
--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -615,7 +615,7 @@ int32 ReadFile(ExtensionString filename, ExtensionString encoding, std::string& 
         return ERR_CANT_READ;
 
     HANDLE hFile = CreateFile(filename.c_str(), GENERIC_READ,
-        0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+        FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
     int32 error = NO_ERROR;
 
     if (INVALID_HANDLE_VALUE == hFile)
@@ -646,7 +646,7 @@ int32 WriteFile(ExtensionString filename, std::string contents, ExtensionString 
         return ERR_UNSUPPORTED_ENCODING;
 
     HANDLE hFile = CreateFile(filename.c_str(), GENERIC_WRITE,
-        0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+        FILE_SHARE_READ, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
     DWORD dwBytesWritten;
     int error = NO_ERROR;
 


### PR DESCRIPTION
@gruehle 

Fixes adobe/brackets#2579. It's not entirely clear why we collide with SimpLESS so often, but this seems to alleviate the issue.

There is some danger that we might write a file while someone else is reading it. That's filed as adobe/brackets#881.
