### PR TITLE
Don't create tags for separator items

### DIFF
--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -798,7 +798,9 @@ int32 AddMenuItem(CefRefPtr<CefBrowser> browser, ExtensionString parentCommand, 
     }
     int32 tag = NativeMenuModel::getInstance(getMenuParent(browser)).getTag(command);
     if (tag == kTagNotFound) {
-        tag = NativeMenuModel::getInstance(getMenuParent(browser)).getOrCreateTag(command, parentCommand);
+        if (!isSeparator) {
+            tag = NativeMenuModel::getInstance(getMenuParent(browser)).getOrCreateTag(command, parentCommand);
+        }
     } else {
         return NO_ERROR;
     }

--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -1249,7 +1249,9 @@ int32 AddMenuItem(CefRefPtr<CefBrowser> browser, ExtensionString parentCommand, 
 
     tag = NativeMenuModel::getInstance(getMenuParent(browser)).getTag(command);
     if (tag == kTagNotFound) {
-        tag = NativeMenuModel::getInstance(getMenuParent(browser)).getOrCreateTag(command, parentCommand);
+        if (!isSeparator) {
+            tag = NativeMenuModel::getInstance(getMenuParent(browser)).getOrCreateTag(command, parentCommand);
+        }
     } else {
         return NO_ERROR;
     }


### PR DESCRIPTION
Fixes adobe/brackets#2613

adobe/brackets#2724 is a corresponding cleanup to the native menu unit tests.

When adding menu separators, don't create a tag. Creating a tag "registers" the item with the native menu model, but separators are not associated with a specific command, and therefore shouldn't be registered.
