### PR TITLE
Remove dev symlinks before nuking cef directory

### DIFF
--- a/scripts/download_deps.sh
+++ b/scripts/download_deps.sh
@@ -26,6 +26,14 @@ if [ -f "$root_dir/deps/cef/$zipName.txt" ]; then
     echo "You already have the correct version of CEF downloaded."
     
 else
+    # remove any "dev" symlinks before nuking the cef folder
+    if [ -d "$root_dir/Release/dev" ]; then
+        rmdir "$root_dir/Release/dev"
+    fi
+    if [ -d "$root_dir/Debug/dev" ]; then
+        rmdir "$root_dir/Debug/dev"
+    fi
+    
     # nuke the old folder
     rm -rf "$root_dir/deps/cef"
     


### PR DESCRIPTION
Fixes adobe/brackets#2925

This was only a problem on Windows. On the Mac, the compiled application is in the `xcodebuild` folder that doesn't get deleted when removing the CEF folder.
