### PR TITLE
Fix chrome launching problems

### DIFF
--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -331,7 +331,7 @@ int32 OpenLiveBrowser(ExtensionString argURL, bool enableRemoteDebugging)
     std::wstring args = appPath;
 
     if (enableRemoteDebugging)
-        args += L" --remote-debugging-port=9222 --user-data-dir=brackets-profile --allow-file-access-from-files ";
+        args += L" --remote-debugging-port=9222 --user-data-dir=brackets-profile --no-first-run --allow-file-access-from-files ";
     else
         args += L" ";
     args += argURL;


### PR DESCRIPTION
This is for https://github.com/adobe/brackets/issues/2370

This adds a new launch flag so chrome uses a different profile on Window. This causes Chrome to open a separate window for brackets Live Preview connections which avoids debugging flag conflicts.

This didn't seem to have any effect on Mac, so it wasn't added.

There is an associated randy/starting-live-dev branch on brackets.
