### PR TITLE
Reduce CloseLiveBrowser() timeout

### DIFF
--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -379,8 +379,8 @@ void CloseLiveBrowser(CefRefPtr<CefBrowser> browser, CefRefPtr<CefProcessMessage
     if (cbData.numberOfFoundWindows == 0) {
         liveBrowserMgr->CloseLiveBrowserFireCallback(NO_ERROR);
     } else if (liveBrowserMgr->GetCloseCallback()) {
-        // set a timeout for up to 3 minutes to close the browser 
-        liveBrowserMgr->SetCloseTimeoutTimerId( ::SetTimer(NULL, 0, 3 * 60 * 1000, LiveBrowserMgrWin::CloseLiveBrowserTimerCallback) );
+        // set a timeout for up to 10 seconds to close the browser
+        liveBrowserMgr->SetCloseTimeoutTimerId( ::SetTimer(NULL, 0, 10 * 1000, LiveBrowserMgrWin::CloseLiveBrowserTimerCallback) );
     }
 }
 


### PR DESCRIPTION
I reduced timeout from 180 seconds to 10 seconds.

When researching https://github.com/adobe/brackets/issues/3243, I noticed that my cpu would hit 100% for the full 3 minutes waiting for this to timeout! Lately, I have noticed my cpu fan turning on and discovered instances of Brackets.exe running at 100% cpu, so this may be the cause.
