### PR TITLE
Use file.addToWorkingSet instead of file.open

### DIFF
--- a/appshell/client_handler.cpp
+++ b/appshell/client_handler.cpp
@@ -343,7 +343,7 @@ bool ClientHandler::SendJSCommand(CefRefPtr<CefBrowser> browser, const CefString
 void ClientHandler::SendOpenFileCommand(CefRefPtr<CefBrowser> browser, const CefString &filename) {
   std::string filenameStr(filename);
   // FIXME: Use SendJSCommand once it supports parameters
-  std::string cmd = "require('command/CommandManager').execute('file.open',{fullPath:'" + filenameStr + "'})";
+  std::string cmd = "require('command/CommandManager').execute('file.addToWorkingSet',{fullPath:'" + filenameStr + "'})";
   browser->GetMainFrame()->ExecuteJavaScript(CefString(cmd.c_str()),
                                 browser->GetMainFrame()->GetURL(), 0);
 }


### PR DESCRIPTION
Fixes adobe/brackets#3355

Use `addToWorkingSet()` instead of `open()` when opening files from the shell.
