### PR TITLE
Fix copy issue in Jasmine window.

### DIFF
--- a/appshell/client_handler_win.cpp
+++ b/appshell/client_handler_win.cpp
@@ -255,7 +255,14 @@ bool ClientHandler::OnPreKeyEvent(CefRefPtr<CefBrowser> browser,
                                     const CefKeyEvent& event,
                                     CefEventHandle os_event,
                                     bool* is_keyboard_shortcut) {
-    if (::TranslateAccelerator((HWND)getMenuParent(browser), hAccelTable, os_event)) {
+    HWND frameHwnd = (HWND)getMenuParent(browser);
+
+    // Don't call ::TranslateAccelerator if we don't have a menu for the current window.
+    if (!GetMenu(frameHwnd)) {
+        return false;
+    }
+
+    if (::TranslateAccelerator(frameHwnd, hAccelTable, os_event)) {
         return true;
     }
 


### PR DESCRIPTION
Don't call ::TranslateAccelerator for a window that doesn't have the menu bar. This fixes issue [#2986](https://github.com/adobe/brackets/issues/2986).
