### PR TITLE
[typo] close the node-core WebSocket server

### DIFF
--- a/appshell/node-core/Server.js
+++ b/appshell/node-core/Server.js
@@ -247,7 +247,7 @@ maxerr: 50, node: true */
             } else {
                 Logger.info("[Server] serving on port", servers.port);
                 _httpServer = servers.httpServer;
-                _wsServer = servers._wsServer;
+                _wsServer = servers.wsServer;
                 // tell the parent process what port we're on
                 sendCommandToParentProcess("port", servers.port);
             }


### PR DESCRIPTION
A little typo has been preventing the node-core WebSocket server from shutting down properly. (For the origin of the mis-typed property, see https://github.com/adobe/brackets-shell/blob/master/appshell/node-core/Server.js#L218) I'm not totally sure, but this may have been preventing the NodeConnection auto-reconnect stuff from working right because the WS server wasn't ever explicitly closing the sockets before shutting down or restarting.

TODO: add static types to JavaScript.
