### PR TITLE
Fix Chrome launch/connect issues on Windows

### DIFF
--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -332,7 +332,7 @@ int32 OpenLiveBrowser(ExtensionString argURL, bool enableRemoteDebugging)
 
     if (enableRemoteDebugging) {
         std::wstring profilePath(ClientApp::AppGetSupportDirectory());
-        profilePath += L"\\brackets-profile";
+        profilePath += L"\\live-dev-profile";
         args += L" --user-data-dir=\"";
         args += profilePath;
         args += L"\" --no-first-run --no-default-browser-check --allow-file-access-from-files --remote-debugging-port=9222 ";


### PR DESCRIPTION
Fixes several Live Preview launch and connect issues on Windows:
- Trouble relaunching Chrome if a background process like Feedly is installed.
- Intermittent connection issues/timeouts.
- Intermittent issues launching Chrome

This request has two main changes:
1. Use cmd.exe "start chrome" to launch chrome. Previously we were finding the chrome executable and launching it directly.
2. Launch chrome with a custom user profile. This launches a new, clean instance of Chrome that does not interfere with any running instances.

There _is_ one potential drawback with the second change. The Chrome instance launched by Brackets will _not_ have the Chrome Extensions, settings, etc. that the user normally sees when running Chrome. We may want to add a Brackets theme to the custom user profile to make the window easily distinguishable from other Chrome windows.
