### PR TITLE
Launch Chrome with the full path to the executable instead of 'start chrome'

### DIFF
--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -348,8 +348,6 @@ int32 OpenLiveBrowser(ExtensionString argURL, bool enableRemoteDebugging)
 
     STARTUPINFO si = {0};
     si.cb = sizeof(si);
-    si.dwFlags = STARTF_USESHOWWINDOW;
-    si.wShowWindow = SW_HIDE;
     PROCESS_INFORMATION pi = {0};
 
     // Launch cmd.exe and pass in the arguments


### PR DESCRIPTION
A couple people have reported a "security error" when starting live development (https://github.com/adobe/brackets/issues/3795). This should resolve that problem.
