### PR TITLE
Move to trash

### DIFF
--- a/appshell/appshell_extensions.cpp
+++ b/appshell/appshell_extensions.cpp
@@ -305,18 +305,20 @@ public:
         } else if (message_name == "MoveFileOrDirectoryToTrash") {
             // Parameters:
             //  0: int32 - callback id
-            //  1: string - filename
+            //  1: string - path
             if (argList->GetSize() != 2 ||
                 argList->GetType(1) != VTYPE_STRING) {
                 error = ERR_INVALID_PARAMS;
             }
             
             if (error == NO_ERROR) {
-                ExtensionString filename = argList->GetString(1);
+                ExtensionString path = argList->GetString(1);
                 
-                error = MoveFileOrDirectoryToTrash(filename);
+                MoveFileOrDirectoryToTrash(path, browser, response);
                 
-                // No additional response args for this function
+                // Skip standard callback handling. MoveFileOrDirectoryToTrash fires the
+                // callback asynchronously.
+                return true;
             }
         } else if (message_name == "ShowDeveloperTools") {
             // Parameters - none

--- a/appshell/appshell_extensions.js
+++ b/appshell/appshell_extensions.js
@@ -373,7 +373,7 @@ if (!appshell.app) {
     /**
      * Delete a file non-permanently (to trash).
      *
-     * @param {string} path The path of the file to delete
+     * @param {string} path The path of the file or directory to delete
      * @param {function(err)} callback Asynchronous callback function. The callback gets one argument (err).
      *        Possible error values:
      *          NO_ERROR

--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -506,16 +506,33 @@ int32 DeleteFileOrDirectory(ExtensionString filename)
     return ConvertNSErrorCode(error, false);
 }
 
-int32 MoveFileOrDirectoryToTrash(ExtensionString filename)
+void MoveFileOrDirectoryToTrash(ExtensionString filename, CefRefPtr<CefBrowser> browser, CefRefPtr<CefProcessMessage> response)
 {
-    NSError* error = nil;
+    NSString* pathStr = [NSString stringWithUTF8String:filename.c_str()];
+    NSURL* fileUrl = [NSURL fileURLWithPath: pathStr];
     
-    NSString* path = [NSString stringWithUTF8String:filename.c_str()];
+    static CefRefPtr<CefProcessMessage> s_response;
+    static CefRefPtr<CefBrowser> s_browser;
     
-    if ([[NSFileManager defaultManager] moveItemAtPath:path toPath:[[@"~/.Trash/" stringByStandardizingPath] stringByAppendingPathComponent:[path lastPathComponent]] error:&error])        
-        return NO_ERROR;
+    if (s_response) {
+        // Already a pending request. This will only happen if MoveFileOrDirectoryToTrash is called
+        // before the previous call has completed, which is not very likely.
+        response->GetArgumentList()->SetInt(1, ERR_UNKNOWN);
+        browser->SendProcessMessage(PID_RENDERER, response);
+        return;
+    }
     
-    return ConvertNSErrorCode(error, false);
+    s_browser = browser;
+    s_response = response;
+    
+    [[NSWorkspace sharedWorkspace] recycleURLs:[NSArray arrayWithObject:fileUrl] completionHandler:^(NSDictionary *newURLs, NSError *error) {
+        // Invoke callback
+        s_response->GetArgumentList()->SetInt(1, ConvertNSErrorCode(error, false));
+        s_browser->SendProcessMessage(PID_RENDERER, s_response);
+        
+        s_response = nil;
+        s_browser = nil;
+    }];
 }
 
 

--- a/appshell/appshell_extensions_platform.h
+++ b/appshell/appshell_extensions_platform.h
@@ -92,7 +92,7 @@ int32 SetPosixPermissions(ExtensionString filename, int32 mode);
 
 int32 DeleteFileOrDirectory(ExtensionString filename);
 
-int32 MoveFileOrDirectoryToTrash(ExtensionString filename);
+void MoveFileOrDirectoryToTrash(ExtensionString filename, CefRefPtr<CefBrowser> browser, CefRefPtr<CefProcessMessage> response);
 
 int32 GetNodeState(int32& state);
 


### PR DESCRIPTION
The is a rebased/squashed version of #245 

Adds a new appshell.fs.moveToTrash() function, which, as it's name implies, moves the specified file or folder to the Trash (on the mac) or Recycle Bin (on Windows).
