### PR TITLE
Fix potential crash when reloading Brackets

### DIFF
--- a/appshell/client_app.cpp
+++ b/appshell/client_app.cpp
@@ -161,7 +161,10 @@ class AppShellExtensionHandler : public CefV8Handler {
           // Pass all messages to the browser process. Look in appshell_extensions.cpp for implementation.
           CefRefPtr<CefBrowser> browser = 
                 CefV8Context::GetCurrentContext()->GetBrowser();
-          ASSERT(browser.get());
+          if (!browser.get()) {
+              // If we don't have a browser, we can't handle the command.
+              return false;
+          }
           CefRefPtr<CefProcessMessage> message = 
                 CefProcessMessage::Create(name);
           CefRefPtr<CefListValue> messageArgs = message->GetArgumentList();


### PR DESCRIPTION
When reloading Brackets, there is a short period of time where the old V8 context is still around, but has been detached from the browser. Any calls to our V8 extensions during that time will fail. Previously, this would crash. With this change, we simply ignore the request and return `false` to signal that we didn't handle the request.
