### PR TITLE
removed TODO comment made obsolete by PR #247

### DIFF
--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -412,25 +412,6 @@ int32 ShowOpenDialog(bool allowMultipleSelection,
     wchar_t szFile[MAX_PATH];
     szFile[0] = 0;
 
-    // TODO (issue #64) - This method should be using IFileDialog instead of the
-    /* outdated SHGetPathFromIDList and GetOpenFileName.
-       
-    Useful function to parse fileTypesStr:
-    template<class T>
-    int inline findAndReplaceString(T& source, const T& find, const T& replace)
-    {
-    int num=0;
-    int fLen = find.size();
-    int rLen = replace.size();
-    for (int pos=0; (pos=source.find(find, pos))!=T::npos; pos+=rLen)
-    {
-    num++;
-    source.replace(pos, fLen, replace);
-    }
-    return num;
-    }
-    */
-
     // Windows common file dialogs can handle Windows path only, not Unix path.
     // ofn.lpstrInitialDir also needs Windows path on XP and not Unix path.
     ConvertToNativePath(initialDirectory);


### PR DESCRIPTION
Removed TODO comment made obsolete by PR #247.  Other than the removal of the comment lines, there was no executable code changed by this PR.

Unfortunately, I overlooked a comment made in the discussion of PR #247, and I should have removed this TODO comment.
