### PR TITLE
Fix for Issue #4077- "brackets-shell: Can't build on Windows"

### DIFF
--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -411,25 +411,6 @@ int32 ShowOpenDialog(bool allowMultipleSelection,
     wchar_t szFile[MAX_PATH];
     szFile[0] = 0;
 
-    // TODO (issue #64) - This method should be using IFileDialog instead of the
-    /* outdated SHGetPathFromIDList and GetOpenFileName.
-       
-    Useful function to parse fileTypesStr:
-    template<class T>
-    int inline findAndReplaceString(T& source, const T& find, const T& replace)
-    {
-    int num=0;
-    int fLen = find.size();
-    int rLen = replace.size();
-    for (int pos=0; (pos=source.find(find, pos))!=T::npos; pos+=rLen)
-    {
-    num++;
-    source.replace(pos, fLen, replace);
-    }
-    return num;
-    }
-    */
-
     // Windows common file dialogs can handle Windows path only, not Unix path.
     // ofn.lpstrInitialDir also needs Windows path on XP and not Unix path.
     ConvertToNativePath(initialDirectory);


### PR DESCRIPTION
removes dependency on Microsoft SDK header file 'atlbase.h', which is not necessarily installed by all releases of Visual Studio.  Removed unnecessary use of ATL class CComPtr, and just managed the IShellItem pointer explicitly.

Also, removed a TODO comment pointed out in and made obsolete by PR# 247 (https://github.com/adobe/brackets-shell/pull/247).

Note: this change only affects the Windows implementation of brackets-shell.  Also, it doesn't change shell behavior at all.
