### PR TITLE
Fix Open Dialog Title 

### DIFF
--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -431,6 +431,7 @@ int32 ShowOpenDialog(bool allowMultipleSelection,
 					IShellItem *shellItem = NULL;
 					if (SUCCEEDED(SHCreateItemFromParsingName(initialDirectory.c_str(), 0, IID_IShellItem, reinterpret_cast<void**>(&shellItem))))
 						pfd->SetFolder(shellItem);
+					pfd->SetTitle(title.c_str());
 					if (SUCCEEDED(pfd->Show(NULL))) {
 						IShellItem *psi;
 						if (SUCCEEDED(pfd->GetResult(&psi))) {


### PR DESCRIPTION
Passing a title to brackets.fs.showOpenFileDialog is ignored and not displayed in the file open dialog title:

https://github.com/adobe/brackets/issues/1574
