### PR TITLE
ignore .aps files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ libcef_dll_wrapper.vcxproj
 *.esproj
 *.xcworkspace
 
+*.aps
 *.pdb
 *.ilk
 *.sdf


### PR DESCRIPTION
ignores app studio files (.aps) which are generated when the project is opened but not used by Brackets nor required to be stored in the repo
