### PR TITLE
Implement modality of a JS dialog in app shell by using a new api.

### DIFF
--- a/appshell/appshell_extensions.cpp
+++ b/appshell/appshell_extensions.cpp
@@ -626,6 +626,22 @@ public:
                 responseArgs->SetString(2, parentId);
                 responseArgs->SetInt(3, index);
             }
+        } else if (message_name == "SetModal") {
+            // Parameters:
+            //  0: int32 - callback id
+            //  1: bool - on or off
+            if (argList->GetSize() != 2 ||
+                argList->GetType(1) != VTYPE_BOOL) {
+                error = ERR_INVALID_PARAMS;
+            }
+            
+            if (error == NO_ERROR) {
+                bool hasModalDialog = argList->GetBool(1);
+                SetModal(hasModalDialog);
+            }
+            
+            // No additional response args for this function
+            
         } else if (message_name == "DragWindow") {     
             // Parameters: none       
             DragWindow(browser);

--- a/appshell/appshell_extensions.cpp
+++ b/appshell/appshell_extensions.cpp
@@ -637,7 +637,7 @@ public:
             
             if (error == NO_ERROR) {
                 bool hasModalDialog = argList->GetBool(1);
-                SetModal(hasModalDialog);
+                handler->SetModal(browser, hasModalDialog);
             }
             
             // No additional response args for this function

--- a/appshell/appshell_extensions.js
+++ b/appshell/appshell_extensions.js
@@ -690,6 +690,14 @@ if (!appshell.app) {
     };
  
     /**
+     * Set the global variable that represents the display of a modal dialog.
+     */
+    native function SetModal();
+    appshell.app.setModal = function (hasModalDialog, callback) {
+        SetModal(callback || _dummyCallback, hasModalDialog);
+    };
+
+    /**
      * Return the user's language per operating system preferences.
      */
     native function GetCurrentLanguage();

--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -629,11 +629,14 @@ void OnBeforeShutdown()
 void CloseWindow(CefRefPtr<CefBrowser> browser)
 {
   NSWindow* window = [browser->GetHost()->GetWindowHandle() window];
+  bool hasModalDialog = [[window delegate] performSelector:@selector(isShowingModalDialog)];
   
   // Tell the window delegate it's really time to close
-  [[window delegate] performSelector:@selector(setIsReallyClosing)];
-  browser->GetHost()->CloseBrowser(true);
-  [window close];
+  if (!hasModalDialog) {
+    [[window delegate] performSelector:@selector(setIsReallyClosing)];
+    browser->GetHost()->CloseBrowser(true);
+    [window close];
+  }
 }
 
 void BringBrowserWindowToFront(CefRefPtr<CefBrowser> browser)

--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -27,6 +27,7 @@
 
 #include <Cocoa/Cocoa.h>
 
+extern bool g_isShowingModalDialog;
 NSMutableArray* pendingOpenFiles;
 
 @interface ChromeWindowsTerminatedObserver : NSObject
@@ -1115,4 +1116,8 @@ void DragWindow(CefRefPtr<CefBrowser> browser)
         [win setFrameOrigin:offset];
         [win displayIfNeeded];
     }
+}
+
+void SetModal(bool hasModalDialog) {
+    g_isShowingModalDialog = hasModalDialog;
 }

--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -27,7 +27,6 @@
 
 #include <Cocoa/Cocoa.h>
 
-extern bool g_isShowingModalDialog;
 NSMutableArray* pendingOpenFiles;
 
 @interface ChromeWindowsTerminatedObserver : NSObject
@@ -1116,8 +1115,4 @@ void DragWindow(CefRefPtr<CefBrowser> browser)
         [win setFrameOrigin:offset];
         [win displayIfNeeded];
     }
-}
-
-void SetModal(bool hasModalDialog) {
-    g_isShowingModalDialog = hasModalDialog;
 }

--- a/appshell/appshell_extensions_platform.h
+++ b/appshell/appshell_extensions_platform.h
@@ -140,5 +140,3 @@ int32 SetMenuItemShortcut(CefRefPtr<CefBrowser> browser, ExtensionString command
 int32 GetMenuPosition(CefRefPtr<CefBrowser> browser, const ExtensionString& commandId, ExtensionString& parentId, int& index);
 
 void DragWindow(CefRefPtr<CefBrowser> browser);
-
-void SetModal(bool hasModalDialog);

--- a/appshell/appshell_extensions_platform.h
+++ b/appshell/appshell_extensions_platform.h
@@ -140,3 +140,5 @@ int32 SetMenuItemShortcut(CefRefPtr<CefBrowser> browser, ExtensionString command
 int32 GetMenuPosition(CefRefPtr<CefBrowser> browser, const ExtensionString& commandId, ExtensionString& parentId, int& index);
 
 void DragWindow(CefRefPtr<CefBrowser> browser);
+
+void SetModal(bool hasModalDialog);

--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -53,6 +53,7 @@ time_t FiletimeToTime(FILETIME const& ft);
 extern HINSTANCE hInst;
 extern HACCEL hAccelTable;
 extern std::wstring gFilesToOpen;
+extern bool g_isShowingModalDialog;
 
 // constants
 #define MAX_LOADSTRING 100
@@ -1685,5 +1686,7 @@ void DragWindow(CefRefPtr<CefBrowser> browser) {
     SendMessage(browserHwnd, WM_NCLBUTTONDOWN, HTCAPTION, 0);
 }
     
-
+void SetModal(bool hasModalDialog) {
+    g_isShowingModalDialog = hasModalDialog;
+}
 

--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -53,7 +53,6 @@ time_t FiletimeToTime(FILETIME const& ft);
 extern HINSTANCE hInst;
 extern HACCEL hAccelTable;
 extern std::wstring gFilesToOpen;
-extern bool g_isShowingModalDialog;
 
 // constants
 #define MAX_LOADSTRING 100
@@ -1684,9 +1683,5 @@ void DragWindow(CefRefPtr<CefBrowser> browser) {
     ReleaseCapture();
     HWND browserHwnd = (HWND)getMenuParent(browser);
     SendMessage(browserHwnd, WM_NCLBUTTONDOWN, HTCAPTION, 0);
-}
-    
-void SetModal(bool hasModalDialog) {
-    g_isShowingModalDialog = hasModalDialog;
 }
 

--- a/appshell/cefclient_mac.mm
+++ b/appshell/cefclient_mac.mm
@@ -152,6 +152,14 @@ extern NSMutableArray* pendingOpenFiles;
   return self;
 }
 
+- (bool)isShowingModalDialog {
+  bool hasModalDialog = false;
+  if (g_handler.get() && g_handler->GetBrowserId()) {
+    hasModalDialog = g_handler->HasModalDialog(g_handler->GetBrowser());
+  }
+  return hasModalDialog;
+}
+
 - (void)setIsReallyClosing {
   isReallyClosing = true;
 }
@@ -175,11 +183,12 @@ extern NSMutableArray* pendingOpenFiles;
     NSInteger menuState = NSOffState;
     NSUInteger tag = [menuItem tag];
     NativeMenuModel menus = NativeMenuModel::getInstance(getMenuParent(g_handler->GetBrowser()));
+    ExtensionString commandId = menus.getCommandId(tag);
     if (menus.isMenuItemChecked(tag)) {
         menuState = NSOnState;
     }
     [menuItem setState:menuState];
-	if (g_handler->HasModalDialog(g_handler->GetBrowser())) {
+	if (g_handler->HasModalDialog(g_handler->GetBrowser()) && !IsEditCommandId(commandId)) {
 	  return false;
 	}
     return menus.isMenuItemEnabled(tag);

--- a/appshell/cefclient_mac.mm
+++ b/appshell/cefclient_mac.mm
@@ -26,6 +26,7 @@ CFTimeInterval g_appStartupTime;
 
 // The global ClientHandler reference.
 extern CefRefPtr<ClientHandler> g_handler;
+bool g_isShowingModalDialog = false;
 static bool g_isTerminating = false;
 
 char szWorkingDir[512];   // The current working directory
@@ -179,6 +180,9 @@ extern NSMutableArray* pendingOpenFiles;
         menuState = NSOnState;
     }
     [menuItem setState:menuState];
+	if (g_isShowingModalDialog) {
+	  return false;
+	}
     return menus.isMenuItemEnabled(tag);
 }
 

--- a/appshell/cefclient_mac.mm
+++ b/appshell/cefclient_mac.mm
@@ -26,7 +26,6 @@ CFTimeInterval g_appStartupTime;
 
 // The global ClientHandler reference.
 extern CefRefPtr<ClientHandler> g_handler;
-bool g_isShowingModalDialog = false;
 static bool g_isTerminating = false;
 
 char szWorkingDir[512];   // The current working directory
@@ -180,7 +179,7 @@ extern NSMutableArray* pendingOpenFiles;
         menuState = NSOnState;
     }
     [menuItem setState:menuState];
-	if (g_isShowingModalDialog) {
+	if (g_handler->HasModalDialog(g_handler->GetBrowser())) {
 	  return false;
 	}
     return menus.isMenuItemEnabled(tag);

--- a/appshell/cefclient_win.cpp
+++ b/appshell/cefclient_win.cpp
@@ -44,7 +44,6 @@ std::wstring gFilesToOpen; // Filenames passed as arguments to app
 TCHAR szTitle[MAX_LOADSTRING];  // The title bar text
 TCHAR szWindowClass[MAX_LOADSTRING];  // the main window class name
 char szWorkingDir[MAX_PATH];  // The current working directory
-bool g_isShowingModalDialog = false;
 
 TCHAR szInitialUrl[MAX_PATH] = {0};
 
@@ -858,7 +857,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam,
 
     case WM_CLOSE:
       if (g_handler.get()) {
-
+        bool hasModalDialog = g_handler->HasModalDialog(g_handler->GetBrowser());
         HWND hWnd = GetActiveWindow();
         SaveWindowRect(hWnd);
 
@@ -870,8 +869,10 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam,
 			break;
 		}
 
-        g_handler->QuittingApp(true);
-        g_handler->DispatchCloseToNextBrowser();
+        if (!hasModalDialog) {
+            g_handler->QuittingApp(true);
+            g_handler->DispatchCloseToNextBrowser();
+        }
         return 0;
       }
       break;
@@ -894,11 +895,13 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam,
         HMENU menu = (HMENU)wParam;
         int count = GetMenuItemCount(menu);
         void* menuParent = getMenuParent(g_handler->GetBrowser());
+        bool hasModalDialog = g_handler->HasModalDialog(g_handler->GetBrowser());
+
         for (int i = 0; i < count; i++) {
             UINT id = GetMenuItemID(menu, i);
 
             bool enabled = NativeMenuModel::getInstance(menuParent).isMenuItemEnabled(id);
-            UINT flagEnabled = (enabled && !g_isShowingModalDialog) ? MF_ENABLED | MF_BYCOMMAND : MF_DISABLED | MF_BYCOMMAND;
+            UINT flagEnabled = (enabled && !hasModalDialog) ? MF_ENABLED | MF_BYCOMMAND : MF_DISABLED | MF_BYCOMMAND;
             EnableMenuItem(menu, id,  flagEnabled);
 
             bool checked = NativeMenuModel::getInstance(menuParent).isMenuItemChecked(id);

--- a/appshell/cefclient_win.cpp
+++ b/appshell/cefclient_win.cpp
@@ -44,6 +44,7 @@ std::wstring gFilesToOpen; // Filenames passed as arguments to app
 TCHAR szTitle[MAX_LOADSTRING];  // The title bar text
 TCHAR szWindowClass[MAX_LOADSTRING];  // the main window class name
 char szWorkingDir[MAX_PATH];  // The current working directory
+bool g_isShowingModalDialog = false;
 
 TCHAR szInitialUrl[MAX_PATH] = {0};
 
@@ -897,7 +898,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam,
             UINT id = GetMenuItemID(menu, i);
 
             bool enabled = NativeMenuModel::getInstance(menuParent).isMenuItemEnabled(id);
-            UINT flagEnabled = enabled ? MF_ENABLED | MF_BYCOMMAND : MF_DISABLED | MF_BYCOMMAND;
+            UINT flagEnabled = (enabled && !g_isShowingModalDialog) ? MF_ENABLED | MF_BYCOMMAND : MF_DISABLED | MF_BYCOMMAND;
             EnableMenuItem(menu, id,  flagEnabled);
 
             bool checked = NativeMenuModel::getInstance(menuParent).isMenuItemChecked(id);

--- a/appshell/client_handler.cpp
+++ b/appshell/client_handler.cpp
@@ -337,7 +337,7 @@ bool ClientHandler::SendJSCommand(CefRefPtr<CefBrowser> browser, const CefString
 
 bool ClientHandler::HasModalDialog(CefRefPtr<CefBrowser> browser) {
     if (browser.get() && modal_browser_window_map_.size() > 0) {
-        BrowserWindowMap::const_iterator it = modal_browser_window_map_.find((HWND)browser->GetHost()->GetWindowHandle());
+        BrowserWindowMap::const_iterator it = modal_browser_window_map_.find(browser->GetHost()->GetWindowHandle());
         return it != modal_browser_window_map_.end();
     }
     return false;

--- a/appshell/client_handler.cpp
+++ b/appshell/client_handler.cpp
@@ -21,6 +21,7 @@ enum client_menu_ids {
 };
 
 ClientHandler::BrowserWindowMap ClientHandler::browser_window_map_;
+ClientHandler::BrowserWindowMap ClientHandler::modal_browser_window_map_;
 
 ClientHandler::ClientHandler()
   : m_MainHwnd(NULL),
@@ -332,6 +333,24 @@ bool ClientHandler::SendJSCommand(CefRefPtr<CefBrowser> browser, const CefString
   }
 
   return browser->SendProcessMessage(PID_RENDERER, message);
+}
+
+bool ClientHandler::HasModalDialog(CefRefPtr<CefBrowser> browser) {
+    if (browser.get() && modal_browser_window_map_.size() > 0) {
+        BrowserWindowMap::const_iterator it = modal_browser_window_map_.find((HWND)browser->GetHost()->GetWindowHandle());
+        return it != modal_browser_window_map_.end();
+    }
+    return false;
+}
+
+void ClientHandler::SetModal(CefRefPtr<CefBrowser> browser, bool hasModalDialog) {
+    if (browser.get()) {
+        if (hasModalDialog) {
+            modal_browser_window_map_[browser->GetHost()->GetWindowHandle()] = browser;
+        } else {
+            modal_browser_window_map_.erase(browser->GetHost()->GetWindowHandle());
+        }
+    }
 }
 
 void ClientHandler::SendOpenFileCommand(CefRefPtr<CefBrowser> browser, const CefString &filename) {

--- a/appshell/client_handler.h
+++ b/appshell/client_handler.h
@@ -203,6 +203,9 @@ class ClientHandler : public CefClient,
   bool AppIsQuitting() { return m_quitting; }
   bool HasWindows() const { return !browser_window_map_.empty(); }
 
+  void SetModal(CefRefPtr<CefBrowser> browser, bool hasModalDialog);
+  bool HasModalDialog(CefRefPtr<CefBrowser> browser);
+
  protected:
   void SetLoading(bool isLoading);
   void SetNavState(bool canGoBack, bool canGoForward);
@@ -259,6 +262,7 @@ class ClientHandler : public CefClient,
   
   typedef std::map< CefWindowHandle, CefRefPtr<CefBrowser> > BrowserWindowMap;
   static BrowserWindowMap browser_window_map_;
+  static BrowserWindowMap modal_browser_window_map_;
                         
   typedef std::map<int32, CefRefPtr<CommandCallback> > CommandCallbackMap;
   int32 callbackId;

--- a/appshell/client_handler_mac.mm
+++ b/appshell/client_handler_mac.mm
@@ -11,6 +11,7 @@
 #include "native_menu_model.h"
 
 extern CefRefPtr<ClientHandler> g_handler;
+bool g_isShowingModalDialog = false;
 
 // ClientHandler::ClientLifeSpanHandler implementation
 
@@ -140,6 +141,9 @@ void ClientHandler::CloseMainWindow() {
         menuState = NSOnState;
     }
     [menuItem setState:menuState];
+	if (g_isShowingModalDialog) {
+	  return false;
+	}
     return menus.isMenuItemEnabled(tag);
 }
 

--- a/appshell/client_handler_mac.mm
+++ b/appshell/client_handler_mac.mm
@@ -141,9 +141,9 @@ void ClientHandler::CloseMainWindow() {
         menuState = NSOnState;
     }
     [menuItem setState:menuState];
-	if (clientHandler->HasModalDialog(browser) && !IsEditCommandId(commandId)) {
-	  return false;
-	}
+    if (clientHandler->HasModalDialog(browser) && !IsEditCommandId(commandId)) {
+      return false;
+    }
     return menus.isMenuItemEnabled(tag);
 }
 
@@ -194,7 +194,7 @@ void ClientHandler::CloseMainWindow() {
     clientHandler->SendJSCommand(browser, FILE_CLOSE_WINDOW, callback);
     return NO;
   }
-
+    
   // Clean ourselves up after clearing the stack of anything that might have the
   // window on it.
   [(NSObject*)[window delegate] performSelectorOnMainThread:@selector(cleanup:)

--- a/appshell/client_handler_mac.mm
+++ b/appshell/client_handler_mac.mm
@@ -11,7 +11,6 @@
 #include "native_menu_model.h"
 
 extern CefRefPtr<ClientHandler> g_handler;
-bool g_isShowingModalDialog = false;
 
 // ClientHandler::ClientLifeSpanHandler implementation
 
@@ -141,7 +140,7 @@ void ClientHandler::CloseMainWindow() {
         menuState = NSOnState;
     }
     [menuItem setState:menuState];
-	if (g_isShowingModalDialog) {
+	if (clientHandler->HasModalDialog(browser)) {
 	  return false;
 	}
     return menus.isMenuItemEnabled(tag);

--- a/appshell/client_handler_win.cpp
+++ b/appshell/client_handler_win.cpp
@@ -15,6 +15,7 @@
 #define CLOSING_PROP L"CLOSING"
 
 extern CefRefPtr<ClientHandler> g_handler;
+extern bool g_isShowingModalDialog;
 
 // WM_DROPFILES handler, defined in cefclient_win.cpp
 extern LRESULT HandleDropFiles(HDROP hDrop, CefRefPtr<ClientHandler> handler, CefRefPtr<CefBrowser> browser);
@@ -161,7 +162,7 @@ LRESULT CALLBACK PopupWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPa
             UINT id = GetMenuItemID(menu, i);
 
             bool enabled = NativeMenuModel::getInstance(menuParent).isMenuItemEnabled(id);
-            UINT flagEnabled = enabled ? MF_ENABLED | MF_BYCOMMAND : MF_DISABLED | MF_BYCOMMAND;
+            UINT flagEnabled = (enabled && !g_isShowingModalDialog) ? MF_ENABLED | MF_BYCOMMAND : MF_DISABLED | MF_BYCOMMAND;
             EnableMenuItem(menu, id,  flagEnabled);
 
             bool checked = NativeMenuModel::getInstance(menuParent).isMenuItemChecked(id);
@@ -250,7 +251,7 @@ bool ClientHandler::OnPreKeyEvent(CefRefPtr<CefBrowser> browser,
     HWND frameHwnd = (HWND)getMenuParent(browser);
 
     // Don't call ::TranslateAccelerator if we don't have a menu for the current window.
-    if (!GetMenu(frameHwnd)) {
+    if (!GetMenu(frameHwnd) || g_isShowingModalDialog) {
         return false;
     }
 

--- a/appshell/command_callbacks.h
+++ b/appshell/command_callbacks.h
@@ -27,6 +27,15 @@ const ExtensionString EDIT_PASTE        = "edit.paste";
 const ExtensionString EDIT_SELECT_ALL   = "edit.selectAll";
 #endif
 
+inline bool IsEditCommandId(ExtensionString commandId) {
+    return (commandId == EDIT_UNDO)  ||
+           (commandId == EDIT_REDO)  ||
+           (commandId == EDIT_CUT)   ||
+           (commandId == EDIT_COPY)  ||
+           (commandId == EDIT_PASTE) ||
+           (commandId == EDIT_SELECT_ALL);
+}
+
 // Base CommandCallback class
 class CommandCallback : public CefBase {
   


### PR DESCRIPTION
This requires another pull request on brackets repo that makes calls to the new api in dialogs.js to have it working. https://github.com/adobe/brackets/pull/4341

A new API setModal is introduced so that Brackets can tell app shell to enforce modality when a JS modal dialog is showing. Before showing the JS dialog, we need to call this api with ``true`` argument; and after dismissing the dialog, we need to call it with ``false`` argument.

When the modality is on, all menu items will be disabled and users will not be able to click on any menu item or using its shortcuts. One exception to this on Mac is that some of the Edit menu items (Undo, Redo, Cut, Copy, Paste and Select All) will still be enabled so that users can use them in text fields in any JS dialog.

Modality is not only enforced on menus and shortcuts, but also on other UIs and shortcuts available on the window title bar. That is. X button and Alt+F4 shortcut will be disabled during the display of a JS dialog.

Although menus and commands won't be available in a JS dialog, dialog-specific shortcuts or key events will be available. For example, Cmd-D, Cmd-. and Escape key to dismiss the dialog.

