### PR TITLE
Set the Live Preview URL after launching Chrome.

### DIFF
--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -193,13 +193,11 @@ int32 OpenLiveBrowser(ExtensionString argURL, bool enableRemoteDebugging)
             parameters = [NSArray arrayWithObjects:
                            @"--remote-debugging-port=9222", 
                            @"--allow-file-access-from-files",
-                           urlString,
                            nil];
         }
         else {
             parameters = [NSArray arrayWithObjects:
                            @"--allow-file-access-from-files",
-                           urlString,
                            nil];
         }
 
@@ -213,7 +211,6 @@ int32 OpenLiveBrowser(ExtensionString argURL, bool enableRemoteDebugging)
         if( ![ws launchApplicationAtURL:appURL options:launchOptions configuration:appConfig error:&error] ) {
             return ERR_UNKNOWN;
         }
-        return NO_ERROR;
     }
     
     // Tell the Browser to load the url


### PR DESCRIPTION
This is a fix for adobe/brackets#4326

When launching Chrome on the mac, set the Live Preview URL _after_ Chrome is launched. For some reason URLs passed on the command line are treated differently than URLs passed after Chrome has started.

This change does have one side effect: if your Chrome startup settings are "Open the New Tab page", you will get a blank tab _and_ your Live Preview page when starting Chrome. Not ideal, but better than hijacking your browser...
