### PR TITLE
Add 'git submodule sync' step to the 'git' grunt task

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -95,6 +95,7 @@ module.exports = function (grunt) {
                 promise = spawn([
                     "git checkout " + this.data.branch,
                     "git pull origin " + this.data.branch,
+                    "git submodule sync",
                     "git submodule update --init --recursive"
                 ], { cwd: repo });
         
@@ -196,7 +197,7 @@ module.exports = function (grunt) {
     
     // task: package
     grunt.registerTask("package", "Package www files", function () {
-        grunt.task.run(["clean:www","copy:www", "copy:samples", "write-config"]);
+        grunt.task.run(["clean:www", "copy:www", "copy:samples", "write-config"]);
     });
     
     // task: write-config


### PR DESCRIPTION
This ensures that all submodule URLs are updated, if needed. See adobe/brackets#4533.

Also fix a JSLint complaint about a missing space.
