### PR TITLE
Revert "Update to cef 3.1547.1337" for Sprint 28 build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -177,7 +177,7 @@ module.exports = function (grunt) {
             }
         },
         "cef": {
-            "version"       : "3.1547.1337"
+            "version"       : "3.1453.1279"
         },
         "node": {
             "version"       : "0.8.20"


### PR DESCRIPTION
This reverts commit f871e6f749f86116d39538406522122ffb6cce4d.
