### PR TITLE
Delete cef_data folder preferences on Brackets uninstall on Windows

### DIFF
--- a/installer/win/Brackets.wxs
+++ b/installer/win/Brackets.wxs
@@ -31,6 +31,40 @@ xmlns:fire="http://schemas.microsoft.com/wix/FirewallExtension">
     <DirectoryRef Id="INSTALLDIR">
     </DirectoryRef>
 
+    <DirectoryRef Id="AppDataFolder">
+	    <Directory Id="MyAppDataFolder" Name="$(var.ProductAppDataLocation)">
+	        <Component Id="MyAppDataFolder" Guid="{C5EA56AE-B7FA-44E6-A7B8-95A25F7EECAF}">
+	            <RegistryValue Root="HKCU" Key="Software\$(var.RegistryRoot)" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
+	            <CreateFolder />
+	            <RemoveFolder Id="MyAppDataFolder" On="uninstall" />
+	        </Component>
+	        <Directory Id="CefDataFolder" Name="cef_data">
+	            <Component Id="CleanupCefDataFolderOnUninstall" Guid="{C909E958-57CC-4E3C-A2FE-D70F97D76FBB}">
+	                <RegistryValue Root="HKCU" Key="Software\$(var.RegistryRoot)" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
+	                <CreateFolder />
+	                <RemoveFile Id="CefDataFiles" Name="*" On="uninstall" />
+	                <RemoveFolder Id="CefDataFolder" On="uninstall" />
+	            </Component>
+	            <Directory Id="LocalStorage" Name="Local Storage">
+	                <Component Id="CleanupLocalStorageFolderOnUninstall" Guid="{EFEB32DA-5843-4332-B048-B0BDB6D2DB33}">
+	                    <RegistryValue Root="HKCU" Key="Software\$(var.RegistryRoot)" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
+	                    <CreateFolder />
+	                    <RemoveFile Id="LocalStorageFiles" Name="*" On="uninstall" />
+	                    <RemoveFolder Id="LocalStorage" On="uninstall" />
+	                </Component>
+	            </Directory>
+	            <Directory Id="GPUCache" Name="GPUCache">
+	                <Component Id="CleanupGPUCacheFolderOnUninstall" Guid="{2C12742D-3C52-4E06-B22C-8E9A1F645FE8}">
+	                    <RegistryValue Root="HKCU" Key="Software\$(var.RegistryRoot)" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
+	                    <CreateFolder />
+	                    <RemoveFile Id="GPUCacheFiles" Name="*" On="uninstall" />
+	                    <RemoveFolder Id="GPUCache" On="uninstall" />
+	                </Component>
+	            </Directory>
+	        </Directory>
+	    </Directory>
+    </DirectoryRef>
+
     <DirectoryRef Id="ProgramMenuFolder">
       <Component Id="StartMenuShortcut" Guid="{1395c753-d0eb-f77e-4b02-db126696c37b}" Win64="no" >
         <Shortcut Id="AppShortcut" Name="!(loc.ProductName) $(var.ProductVersionName)"
@@ -68,6 +102,7 @@ xmlns:fire="http://schemas.microsoft.com/wix/FirewallExtension">
         <Directory Id='INSTALLDIR' Name='!(loc.ShortProductName) $(var.ProductVersionName)'/>
       </Directory>
       <Directory Id="ProgramMenuFolder"/>
+      <Directory Id="AppDataFolder" />
     </Directory>
     
     <!-- Set default install location -->    
@@ -78,6 +113,12 @@ xmlns:fire="http://schemas.microsoft.com/wix/FirewallExtension">
       <ComponentGroupRef Id='BRACKETSHARVESTMANAGER'/>
         
       <ComponentRef  Id='StartMenuShortcut' />
+
+      <!-- For cleaning up cef data on uninstall -->
+      <ComponentRef Id="CleanupLocalStorageFolderOnUninstall" />
+      <ComponentRef Id="CleanupGPUCacheFolderOnUninstall" />
+      <ComponentRef Id="CleanupCefDataFolderOnUninstall" />
+      <ComponentRef Id="MyAppDataFolder" />
     </Feature>                  
   </Product>
 </Wix>

--- a/installer/win/brackets-win-install-build.xml
+++ b/installer/win/brackets-win-install-build.xml
@@ -12,6 +12,7 @@ default="build.mul">
   <!-- See also: product name definitions in Brackets_<locale>.wxl -->
   <property name="product.shortname" value="Brackets"/>
   <property name="product.fullname" value="Brackets"/>
+  <property name="product.AppData.location" value="Brackets"/>
   <property name="product.sprint.number" value="30"/>
   <property name="product.version.number" value="0.${product.sprint.number}"/>
   <property name="product.version.name" value="Sprint ${product.sprint.number}"/>
@@ -53,6 +54,7 @@ default="build.mul">
 		              -dcodepage=1252
 		              -dProductVersionNumber='${product.version.number}'
 		              -dProductVersionName='${product.version.name}'
+		              -dProductAppDataLocation='${product.AppData.location}'
 		              -dProductManufacturer='${product.manufacturer}'
 		              -dRegistryRoot='${product.registry.root}'
 		              -dExeName='${product.shortname}'
@@ -107,6 +109,7 @@ default="build.mul">
 		              -dcodepage=1252
 		              -dProductVersionNumber='${product.version.number}'
 		              -dProductVersionName='${product.version.name}'
+		              -dProductAppDataLocation='${product.AppData.location}'
 		              -dProductManufacturer='${product.manufacturer}'
 		              -dRegistryRoot='${product.registry.root}'
 		              -dExeName='${product.shortname}'


### PR DESCRIPTION
This change updates the Windows installer scripts so that uninstalling Brackets on Windows (eg. via Control Panel - Programs and Features) will also delete the AppData\Roaming\Brackets\cef_data folder. It does not remove any installed extensions.

This change was originally provided to EdgeCode by the RE team. So, just making this change available to Brackets, if y'all want it.
