### PR TITLE
Setup proxy icon if page title denotes existing absolute path

### DIFF
--- a/appshell/client_handler_mac.mm
+++ b/appshell/client_handler_mac.mm
@@ -56,8 +56,25 @@ void ClientHandler::OnTitleChange(CefRefPtr<CefBrowser> browser,
   NSWindow* window = [view window];
   std::string titleStr(title);
   NSString* str = [NSString stringWithUTF8String:titleStr.c_str()];
-  [window setTitle:str];
-    
+
+  NSString* path;
+  BOOL isDirty;
+  if ([str hasPrefix:@"\u2022 "]) {
+    isDirty = YES;
+    path = [str substringFromIndex:2];
+  } else {
+    isDirty = NO;
+    path = str;
+  }
+
+  if ([[NSFileManager defaultManager] fileExistsAtPath:path isDirectory:NO]) {
+    [window setTitleWithRepresentedFilename:path];
+    [window setDocumentEdited:isDirty];
+  } else {
+    [window setTitle:str];
+    [window setRepresentedFilename:@""];
+    [window setDocumentEdited:NO];
+  }
   NSObject* delegate = [window delegate];
   [delegate performSelectorOnMainThread:@selector(windowTitleDidChange:) withObject:str waitUntilDone:NO];
 }


### PR DESCRIPTION
This change makes the shell to show proper document proxy icon if the page title is a path to existing local file. It will also recognize dirty mark and will properly update the state of the icon.

I have a matching change to the Brackets JS code that I can submit if this pull request is integrated. By itself, this pull request does not alter visible shell behavior.
