### PR TITLE
Fix Issue #5308- "Win: Two Open With entries for Brackets Sprint 31 if Sprint 30 is already installed"

### DIFF
--- a/installer/win/Brackets.wxs
+++ b/installer/win/Brackets.wxs
@@ -62,7 +62,8 @@ xmlns:fire="http://schemas.microsoft.com/wix/FirewallExtension">
 
         <!-- create ProgId entry -->
         <RegistryValue Root="HKLM" Key="SOFTWARE\Classes\!(loc.ProductName) $(var.ProductVersionName) FileExt\shell\open\command" Value="&quot;[INSTALLDIR]$(var.ExeName).exe&quot; &quot;%1&quot;" Type="string" />
-        <RegistryValue Root="HKLM" Key="SOFTWARE\Classes\Applications\$(var.ExeName).exe\shell\open" Name="FriendlyAppName" Value="!(loc.ProductName) $(var.ProductVersionName)" Type="string" />
+        <RegistryValue Root="HKLM" Key="SOFTWARE\Classes\!(loc.ProductName) $(var.ProductVersionName) FileExt\DefaultIcon" Value="[INSTALLDIR]$(var.ExeName).exe,0" Type="string" />
+        <RegistryValue Root="HKLM" Key="SOFTWARE\Classes\!(loc.ProductName) $(var.ProductVersionName) FileExt\shell\open" Name="FriendlyAppName" Value="!(loc.ProductName) $(var.ProductVersionName)" Type="string" />
 
     </Component>
     <!-- Start Menu Shortcuts-->


### PR DESCRIPTION
Update the Windows installer to register the friendly app name and the default icon with the ProgID, rather than at a single .exe name.

This change only affects the Brackets installer on Windows.

This will correctly register the displayed "Open With" name for the next release of Brackets (ie. Brackets Sprint 32).  It will not fix the already existing case between Brackets Sprint 31 and 30, as noted in [issue #5308](https://github.com/adobe/brackets/issues/5308).
