### PR TITLE
Explicitly call Python2 to run gyp on Linux.

### DIFF
--- a/tasks/setup.js
+++ b/tasks/setup.js
@@ -307,9 +307,8 @@ module.exports = function (grunt) {
             promise,
             gypCommand;
         
-        // TODO why doesn't gyp (in the repository) work for linux?
         if (platform === "linux") {
-            gypCommand = "gyp --depth .";
+            gypCommand = "bash -c 'python2 gyp/gyp --depth=.'";
         } else {
             gypCommand = "bash -c 'gyp/gyp appshell.gyp -I common.gypi --depth=.'";
         }


### PR DESCRIPTION
Python usually refers to the latest version. If there is version 3 installed, it resolves to the the Python 3 interpreter. This change ensures that Python 2 is used. There is no need to install gyp on a Linux machines anymore.
