### PR TITLE
Irichter/fix 5294

### DIFF
--- a/appshell/appshell_extensions_gtk.cpp
+++ b/appshell/appshell_extensions_gtk.cpp
@@ -62,15 +62,24 @@ int GErrorToErrorCode(GError *gerror) {
 
 int32 OpenLiveBrowser(ExtensionString argURL, bool enableRemoteDebugging)
 {
-    const char *remoteDebuggingFormat = "--no-first-run --no-default-browser-check --allow-file-access-from-files --temp-profile --user-data-dir=/tmp/chrome-brackets --remote-debugging-port=9222";
+    const char *remoteDebuggingFormat = "--no-first-run --no-default-browser-check --allow-file-access-from-files --temp-profile --user-data-dir=%s --remote-debugging-port=9222";
     gchar *remoteDebugging;
     gchar *cmdline;
     int error = ERR_BROWSER_NOT_INSTALLED;
     GError *gerror = NULL;
     
     if (enableRemoteDebugging) {
-        // FIXME Should we mimic windows? user-data-dir=ClientApp::AppGetSupportDirectory()
-        remoteDebugging = g_strdup(remoteDebuggingFormat);
+        CefString appSupportDirectory = ClientApp::AppGetSupportDirectory();
+
+        // TODO: (INGO) to better understand to string conversion issue, I need a consultant
+        // here. Getting the char* from CefString I had to call ToString().c_str()
+        // Calling only c_str() didn't return anything.
+        gchar *userDataDir = g_strdup_printf("%s/live-dev-profile",
+                                        appSupportDirectory.ToString().c_str());  
+        g_message("USERDATADIR= %s", userDataDir);
+        remoteDebugging = g_strdup_printf(remoteDebuggingFormat, userDataDir);
+        
+        g_free(userDataDir);
     } else {
         remoteDebugging = g_strdup("");
     }

--- a/appshell/cefclient_gtk.cpp
+++ b/appshell/cefclient_gtk.cpp
@@ -142,6 +142,7 @@ int main(int argc, char* argv[]) {
 
   g_appStartupTime = time(NULL);
 
+  gtk_init(&argc, &argv);
   CefRefPtr<ClientApp> app(new ClientApp);
 
   // Execute the secondary process, if any.
@@ -154,8 +155,6 @@ int main(int argc, char* argv[]) {
     return -1;
 
   GtkWidget* window;
-
-  gtk_init(&argc, &argv);
 
   // Parse command line arguments.
   AppInitCommandLine(argc, argv);

--- a/appshell/client_app_gtk.cpp
+++ b/appshell/client_app_gtk.cpp
@@ -81,9 +81,11 @@ double ClientApp::GetElapsedMilliseconds()
 
 CefString ClientApp::AppGetSupportDirectory() 
 {
-    // FIXME (jasonsanjose): hardcode "brackets"...why doesn't g_get_prgname() work here?
-    gchar *supportDir = g_strdup_printf("%s/brackets", g_get_user_config_dir());
-    return CefString(supportDir);
+    gchar *supportDir = g_strdup_printf("%s/%s", g_get_user_config_dir(), g_get_prgname());
+    CefString result = CefString(supportDir);
+    g_free(supportDir);
+    
+    return result;
 }
 
 CefString ClientApp::AppGetDocumentsDirectory() 


### PR DESCRIPTION
This change fixes adobe/brackets#5294.

The live development didn't work if the path for the `--user-data-dir` (passed to Chrome(-ium) command line didn't exist. Previously we constructed a path to /tmp/, but some users reported that this didn't work on their systems.
In order to fix this behavior, we now use the appSupportDirectory to store the user data directory.

The new place for the user-data-dir is now in `~/.config/Brackets/live-dev-profile`.
To find the place of the appSupportDirectory, the call to `gtk_init` had to be the first when the app starts to make sure that g_get_prgname() and g_get_config_dir() will return valid locations.
