### PR TITLE
Fix rendering of gtk menus

### DIFF
--- a/appshell/appshell_extensions_gtk.cpp
+++ b/appshell/appshell_extensions_gtk.cpp
@@ -565,7 +565,7 @@ GtkWidget* GetMenuBar(CefRefPtr<CefBrowser> browser)
     for(iter = children; iter != NULL; iter = g_list_next(iter)) {
         widget = (GtkWidget*)iter->data;
 
-        if (GTK_IS_CONTAINER(widget))
+        if (GTK_IS_MENU_BAR(widget))
             return widget;
     }
 
@@ -587,6 +587,7 @@ int32 AddMenu(CefRefPtr<CefBrowser> browser, ExtensionString title, ExtensionStr
     GtkWidget* menuHeader = gtk_menu_item_new_with_label(title.c_str());
     gtk_menu_item_set_submenu(GTK_MENU_ITEM(menuHeader), menuWidget);
     gtk_menu_shell_append(GTK_MENU_SHELL(menuBar), menuHeader);
+    gtk_widget_show(menuHeader);
 
     // FIXME add lookup for menu widgets
     _menuWidget = menuWidget;
@@ -605,6 +606,7 @@ int32 AddMenuItem(CefRefPtr<CefBrowser> browser, ExtensionString parentCommand, 
     g_signal_connect(entry, "activate", FakeCallback, NULL);
     // FIXME add lookup for menu widgets
     gtk_menu_shell_append(GTK_MENU_SHELL(_menuWidget), entry);
+    gtk_widget_show(entry);
 
     return NO_ERROR;
 }

--- a/appshell/appshell_extensions_platform.h
+++ b/appshell/appshell_extensions_platform.h
@@ -60,9 +60,9 @@ inline void* getMenuParent(CefRefPtr<CefBrowser>browser) {return NULL;} // Mac u
 #else
 typedef std::string ExtensionString;
 inline void* getMenuParent(CefRefPtr<CefBrowser>browser) {
-    gtk_widget_get_ancestor(
+    return gtk_widget_get_ancestor(
         GTK_WIDGET(browser->GetHost()->GetWindowHandle()),
-        GTK_TYPE_WINDOW);
+        GTK_TYPE_VBOX);
 }
 #endif
 


### PR DESCRIPTION
- Fixed the linux `getMenuParent` to return the correct parent of the menu
- Fixed `AddMenu` and `AddMenuItem` to show the added menu/item

Menus now render natively when `Global.js` allows, however commands are not yet attached and the API is still not implemented properly. All this includes so far is fixes to make it work at the most basic level.

_Note: I'm learning GTK and C especially for this, so I might need a little bit of hand holding with the NativeMenuModel integration. I'll try to look into that soonish, but let me know if anyone else is working on it already :)_
