### PR TITLE
[Mac] Accept folder dropped on shell icon

### DIFF
--- a/appshell/mac/Info.plist
+++ b/appshell/mac/Info.plist
@@ -29,6 +29,16 @@
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>
+			<key>CFBundleTypeOSTypes</key>
+			<array>
+				<string>fold</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleTypeName</key>
+			<string>Folder</string>
+		</dict>
+		<dict>
 			<key>CFBundleTypeName</key>
 			<string>Text files</string>
 			<key>CFBundleTypeRole</key>


### PR DESCRIPTION
I don't have a JS-side implementation yet - this simply enables the Dock icon feedback and passes the path to openFile in application delegate. JS code currently merrily reports an error. I also plan to take a look at JS code.
