### PR TITLE
Don't use NSFileManager api for path existence detection in IsNetworkDrive api.

### DIFF
--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -362,17 +362,17 @@ int32 IsNetworkDrive(ExtensionString path, bool& isRemote)
         return ERR_INVALID_PARAMS;
     }
 
-    // No need to detect network drive if the path does not exist.
-    if (![[NSFileManager defaultManager] fileExistsAtPath:pathStr]) {
-        return ERR_NOT_FOUND;
-    }
-    
     // Detect remote drive
     NSString *testPath = [pathStr copy];
+    NSNumber *isVolumeKey;
+    NSError *error = nil;
+
     while (![testPath isEqualToString:@"/"]) {
         NSURL *testUrl = [NSURL fileURLWithPath:testPath];
-        NSNumber *isVolumeKey;
-        [testUrl getResourceValue:&isVolumeKey forKey:NSURLIsVolumeKey error:nil];
+
+        if (![testUrl getResourceValue:&isVolumeKey forKey:NSURLIsVolumeKey error:&error]) {
+            return ERR_NOT_FOUND;
+        }
         if ([isVolumeKey boolValue]) {
             isRemote = true;
             break;


### PR DESCRIPTION
<del>This fixes the debug issue (https://github.com/adobe/brackets/issues/5277) introduced by pull request https://github.com/adobe/brackets-shell/pull/281 and also fixes https://github.com/adobe/brackets/issues/4410 that pull request tried to fix.</del>


This simplifies the code in checking the existence of file/folder path on Mac. The original code added to fix https://github.com/adobe/brackets/issues/4410 is somehow making debug crash issue (https://github.com/adobe/brackets/issues/5277) happening sooner in a debugging session. 
