### PR TITLE
Set TMPDIR, TMP and TEMP env vars early during launch before domains are loaded

### DIFF
--- a/appshell/node-core/Launcher.js
+++ b/appshell/node-core/Launcher.js
@@ -29,7 +29,8 @@ maxerr: 50, node: true */
     "use strict";
     
     var Logger = require("./Logger"),
-        Server = require("./Server");
+        Server = require("./Server"),
+        os     = require("os");
     
     /** @define {boolean} Whether debugger should be enabled at launch
      *
@@ -122,6 +123,11 @@ maxerr: 50, node: true */
             });
         };
         process._debugProcess(process.pid);
+    }
+
+    // Set environment variable to use built-in Node.js API for temp directory
+    if (!process.env["TMPDIR"] && !process.env["TMP"] && !process.env["TEMP"]) {
+        process.env["TMPDIR"] = process.env["TMP"] = process.env["TEMP"] = os.tmpdir();
     }
     
     exports.launch = launch;


### PR DESCRIPTION
Fix for https://github.com/adobe/brackets/issues/5513.

I found an alternate fix from #358 by setting setting the env vars in node instead of in the native shell code. `osenv` memo-izes `tmpdir` before I can patch the environment vars in `ExtensionManagerDomain.js` in core code, so that's why I chose to do this earlier in `Launcher.js` in the shell.

@ingorichter or @JeffryBooher what do you think of this proposal vs. #358? Not as easy as I would have liked. I was hoping to avoid shell changes.
