### PR TITLE
Write the contents of the file with fwrite instead of g_file_set_contents

### DIFF
--- a/appshell/appshell_extensions_gtk.cpp
+++ b/appshell/appshell_extensions_gtk.cpp
@@ -337,6 +337,7 @@ int ReadFile(ExtensionString filename, ExtensionString encoding, std::string& co
     return error;
 }
 
+
 int32 WriteFile(ExtensionString filename, std::string contents, ExtensionString encoding)
 {
     const char *filenameStr = filename.c_str();    
@@ -358,7 +359,7 @@ int32 WriteFile(ExtensionString filename, std::string contents, ExtensionString 
 
         fclose(file);
     } else {
-        error = errno;
+        return ConvertLinuxErrorCode(errno);
     }
 
     return error;


### PR DESCRIPTION
Since g_file_set_contents removes the file and re-creates it, all permissions get lost during this operation. Using fwrite preserves all the permissions.
