### PR TITLE
Extend the folder drop on icon to any file type on mac. 

### DIFF
--- a/appshell/mac/Info.plist
+++ b/appshell/mac/Info.plist
@@ -29,14 +29,22 @@
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>
-			<key>CFBundleTypeOSTypes</key>
-			<array>
-				<string>fold</string>
-			</array>
+			<key>CFBundleTypeName</key>
+			<string>Document</string>
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
-			<key>CFBundleTypeName</key>
-			<string>Folder</string>
+			<key>CFBundleTypeOSTypes</key>
+			<array>
+				<string>****</string>
+			</array>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>gif</string>
+				<string>jpe</string>
+				<string>jpeg</string>
+				<string>jpg</string>
+				<string>png</string>
+			</array>
 		</dict>
 		<dict>
 			<key>CFBundleTypeName</key>


### PR DESCRIPTION
Also allow user to use "Open With" for image file extensions. This fixes issue https://github.com/adobe/brackets/issues/5759

@eugeneo Can you review this and comment if you see something not right? 
@bchintx I think you should review this too.
