### PR TITLE
Fix crash when closing Chrome without a callback function in place

### DIFF
--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -151,19 +151,23 @@ void LiveBrowserMgrMac::CloseLiveBrowserKillTimers()
 
 void LiveBrowserMgrMac::CloseLiveBrowserFireCallback(int valToSend)
 {
-    CefRefPtr<CefListValue> responseArgs = m_closeLiveBrowserCallback->GetArgumentList();
-    
     // kill the timers
     CloseLiveBrowserKillTimers();
 
     // Stop listening for ws shutdown notifications
     RemoveWorkspaceNotifications();
 
-    // Set common response args (callbackId and error)
-    responseArgs->SetInt(1, valToSend);
-    
-    // Send response
-    m_browser->SendProcessMessage(PID_RENDERER, m_closeLiveBrowserCallback);
+    // Prepare response
+    if (m_closeLiveBrowserCallback) {
+
+        CefRefPtr<CefListValue> responseArgs = m_closeLiveBrowserCallback->GetArgumentList();
+
+        // Set common response args (callbackId and error)
+        responseArgs->SetInt(1, valToSend);
+
+        // Send response
+        m_browser->SendProcessMessage(PID_RENDERER, m_closeLiveBrowserCallback);
+    }
     
     // Clear state
     m_closeLiveBrowserCallback = NULL;


### PR DESCRIPTION
This is for https://github.com/adobe/brackets/issues/5893
