### PR TITLE
Dev tools should not use the debug connection

### DIFF
--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -261,15 +261,22 @@ int32 OpenLiveBrowser(ExtensionString argURL, bool enableRemoteDebugging)
         NSArray *parameters = nil;
         NSString *profilePath = [NSString stringWithFormat:@"--user-data-dir=%@", GetUserProfilePath()];
 
-        parameters = [NSArray arrayWithObjects:
-                      debugPortCommandlineArguments,
-                      @"--allow-file-access-from-files",
-                      @"--no-first-run",
-                      @"--no-default-browser-check",
-                      @"--temp-profile",
-                      profilePath,
-                      urlString,
-                      nil];
+        if (enableRemoteDebugging) {
+            parameters = [NSArray arrayWithObjects:
+                          debugPortCommandlineArguments,
+                          @"--allow-file-access-from-files",
+                          @"--no-first-run",
+                          @"--no-default-browser-check",
+                          @"--temp-profile",
+                          profilePath,
+                          urlString,
+                          nil];
+        }
+        else {
+            parameters = [NSArray arrayWithObjects:
+                          urlString,
+                          nil];
+        }
 
         NSDictionary* appConfig = [NSDictionary dictionaryWithObject:parameters forKey:NSWorkspaceLaunchConfigurationArguments];
 


### PR DESCRIPTION
This pull request is to only use debug connection when `enableRemoteDebugging` is true (e.g. Dev Tools). This is important because Brackets currently can only have 1 debug connection. 

@fungl164 Can you please review this change?

There's 1 case that's not working as expected:
1. Open Chrome (i.e. default profile)
2. Starting Live Dev uses live-dev-profile
3. Give focus to Chrome window using default profile
4. Switch back to Brackets
5. Debug > Show Developer Tools

Results:
Dev Tools are opened in tab in live-dev-profile window.

Expected:
Opening Dev Tools does _not_ specify which Chrome profile to use, so I would expect it to use the frontmost Chrome window. I though this was how Windows worked, but it seems to use default profile even if live-dev-profile is frontmost.

Which Chrome profile is used is not a big deal. The important thing is that the Dev Tools window does not use the debug connection. But, if it's an easy fix to make it work consistently across platforms, then we might want to take it.

cc @njx
