### PR TITLE
Open dev tools in Brackets instead of Chrome

### DIFF
--- a/appshell/appshell_extensions.cpp
+++ b/appshell/appshell_extensions.cpp
@@ -357,11 +357,7 @@ public:
         } else if (message_name == "ShowDeveloperTools") {
             // Parameters - none
             
-            // The CEF-hosted dev tools do not work. Open in a separate browser window instead.
-            // handler->ShowDevTools(browser);
-            
-            ExtensionString url(browser->GetHost()->GetDevToolsURL(true));
-            OpenLiveBrowser(url, false);
+            handler->ShowDevTools(browser);
         } else if (message_name == "GetNodeState") {
             // Parameters:
             //  0: int32 - callback id

--- a/appshell/client_handler_mac.mm
+++ b/appshell/client_handler_mac.mm
@@ -243,7 +243,14 @@ Class GetPopuplWindowFrameClass() {
         menuState = NSOnState;
     }
     [menuItem setState:menuState];
-    return menus.isMenuItemEnabled(tag);
+    
+    BOOL enabled = menus.isMenuItemEnabled(tag);
+    
+    if (browser->GetMainFrame()->GetURL().ToString().find("/devtools/devtools.html") != std::string::npos) {
+        // This is a dev tools window, disable all commands except Quit
+        enabled = [menuItem action] == @selector(quit:);
+    }
+    return enabled;
 }
 
 - (void)setClientHandler:(CefRefPtr<ClientHandler>) handler {


### PR DESCRIPTION
This is done for two reasons:
1. Because we can. (We used to open up DevTools in Brackets back when we used CEF1, but changed because that broke with early versions of CEF3. CEF has fixed these problems).
2. Because opening DevTools in Chrome will be breaking soon. See https://code.google.com/p/chromiumembedded/issues/detail?id=659 for details.

Opening DevTools in Brackets was the easy part. The tricky part was getting the DevTools keyboard shortcuts to work on the Mac. To do this, all menu items except Quit (and the Window menu items) are disabled when a DevTools window is open. This is not required on Windows or Linux because they don't have a global menu bar.
