### PR TITLE
Don't DrawMenuBar() for every menu item

### DIFF
--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -1474,7 +1474,6 @@ int32 AddMenuItem(CefRefPtr<CefBrowser> browser, ExtensionString parentCommand, 
     }
     
     NativeMenuModel::getInstance(getMenuParent(browser)).setOsItem(tag, (void*)submenu);
-    DrawMenuBar((HWND)getMenuParent(browser));
 
     if (!isSeparator && !UpdateAcceleratorTable(tag, keyStr)) {
         title = title.substr(0, title.find('\t'));


### PR DESCRIPTION
Doesn't seem to be necessary to `DrawMenuBar()` on every menu item as it's added on Windows.`SetMenuTitle()` already sets a time to do that.

This seems to reduce start up time by ~3/4 second on my lenovo W510 running Win7. Also draws all core menus in menubar at once, followed by a second draw for extensions. Currently, the only extension that adds a menu it the builtin Debug menu, so this should be tested with other extensions that add menus (e.g. Emmet).

This is for https://github.com/adobe/brackets/issues/5266, but there may be more that can be done.

Windows-only.
