### PR TITLE
Fix OpenLiveBrowser issue with Chrome ghost window 

### DIFF
--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -319,7 +319,7 @@ int32 OpenLiveBrowser(ExtensionString argURL, bool enableRemoteDebugging)
     }
 
     GoogleChromeWindow* chromeWindow = [[chromeApp windows] objectAtIndex:0];
-    if(!chromeWindow){
+    if (!chromeWindow || [[chromeWindow tabs] count] == 0) {
         // Create new LiveBrowser Window
         GoogleChromeWindow* chromeWindow = [[[chromeApp classForScriptingClass:@"window"] alloc] init];
         [[chromeApp windows] addObject:chromeWindow];


### PR DESCRIPTION
Fixes problem opening pages when Chrome is in a half-open state (e.g. running process with an invisible window object which has no tabs)

This is for https://github.com/adobe/brackets/issues/5946
