### PR TITLE
Fix regex in grunt set-sprint task

### DIFF
--- a/tasks/set-sprint.js
+++ b/tasks/set-sprint.js
@@ -78,7 +78,7 @@ module.exports = function (grunt) {
         text = grunt.file.read(buildInstallerScriptPath);
         text = safeReplace(
             text,
-            /(Brackets Sprint )([0-9]+)/,
+            /( Sprint )([0-9]+)/,
             "$1" + sprint
         );
         grunt.file.write(buildInstallerScriptPath, text);


### PR DESCRIPTION
Inadvertantly broke the grunt set-sprint task when implementing the Brackets update in-place installer changes in Pull Request #370.  This change updates the regex to properly replace sprint # in installer/mac/buildInstaller.sh.

This broke after I separated the Sprint suffix from the app name.  The updated regex will correctly replace the Sprint # in the dmg filename.
