### PR TITLE
Remove unnecessary include

### DIFF
--- a/appshell/appshell_extensions_gtk.cpp
+++ b/appshell/appshell_extensions_gtk.cpp
@@ -33,7 +33,6 @@
 #include <dirent.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <linux/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <X11/Xlib.h>


### PR DESCRIPTION
Fix for https://github.com/adobe/brackets/issues/6128. Assigned @JeffryBooher.
