### PR TITLE
Fix browser launch params variable assignment before freeing memory

### DIFF
--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -1403,10 +1403,11 @@ int32 GetArgvFromProcessID(int pid, NSString **argv)
         goto ERROR_B;
     }
 
+    *argv = [NSString stringWithCString:sp encoding:NSUTF8StringEncoding];
+
     /* Clean up. */
     free(procargs);
 
-    *argv = [NSString stringWithCString:sp encoding:NSUTF8StringEncoding];
     return NO_ERROR;
 
 ERROR_B:


### PR DESCRIPTION
This for https://github.com/adobe/brackets/issues/6166
