### PR TITLE
Simplify Node domain event specifications

### DIFF
--- a/appshell/node-core/DomainManager.js
+++ b/appshell/node-core/DomainManager.js
@@ -290,7 +290,7 @@ maxerr: 50, node: true */
                 eventNames.forEach(function (eventName) {
                     d.events.push({
                         name: eventName,
-                        parameters: _domains[domainName].events[eventName]
+                        parameters: _domains[domainName].events[eventName].parameters
                     });
                 });
                 _cachedDomainDescriptions.push(d);


### PR DESCRIPTION
This pull request simplifies the event specifications in the exposed Node domains API by removing a redundant single-property object in favor of just the value of that property. That is, it changes the exposed API from this: 

```
{
  "domain": "base",
  "events": [
  {
    "name": "log",
    "parameters": {
      "parameters": [
        {
          "name": "level",
          "type": "string"
        }
      }
    ]
  }
}
```

to this:

```
{
  "domain": "base",
  "events": [
  {
    "name": "log",
    "parameters": [
      {
        "name": "level",
        "type": "string"
      }
    ]
  }
}
```

This should be merged simultaneously with adobe/brackets#6154.

CC @jasonsanjose
