### PR TITLE
Fix installer build job on windows

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -58,7 +58,7 @@ module.exports = function (grunt) {
         var done = this.async(),
             repo = resolve(grunt.config("git.www.repo"));
         
-        spawn(["bash -c 'grunt build'"], { cwd: repo }).then(function (result) {
+        spawn(["bash -c grunt build"], { cwd: repo }).then(function (result) {
             done();
         }, function (err) {
             grunt.log.error(err);


### PR DESCRIPTION
Windows installer build job was failing because `grunt` could not be found in the brackets window when spinning off a child process. Forgot to test this on windows initially. Tested this change on mac, windows and linux this time.

This was a regression from #385 merged this morning.
