### PR TITLE
Added plist setting so integrated GPU is used on Macs with dual GPUs.

### DIFF
--- a/appshell/mac/Info.plist
+++ b/appshell/mac/Info.plist
@@ -26,6 +26,8 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
After enabling the integrated GPU rather than the discrete GPU, Brackets power usage declines and dramatically increases the battery life of Macs with dual GPUs.

Tested on Early 2013 Macbook Pro with Retina display.
All unit tests passed.
