### PR TITLE
Fix removing menu dividers

### DIFF
--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -1098,8 +1098,9 @@ int32 AddMenuItem(CefRefPtr<CefBrowser> browser, ExtensionString parentCommand, 
                     [newItem setKeyEquivalent:keyStr];
                     [newItem setKeyEquivalentModifierMask:mask];
                     [newItem setTag:tag];
-                    NativeMenuModel::getInstance(getMenuParent(browser)).setOsItem(tag, (void*)newItem);
                 }
+                NativeMenuModel::getInstance(getMenuParent(browser)).setOsItem(tag, (void*)newItem);
+                
                 NSInteger positionIdx = -1;
                 int32 errCode = getNewMenuPosition(browser, subMenu, position, relativeId, positionIdx);
                 if (positionIdx > -1) {


### PR DESCRIPTION
Mac: need to set os item for dividers.

This is for https://github.com/adobe/brackets/issues/6300. This pull request requires https://github.com/adobe/brackets/pull/6333.
