### PR TITLE
Fix remove menu performance on Windows

### DIFF
--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -50,7 +50,7 @@ static std::wstring GetPathToLiveBrowser();
 static bool ConvertToShortPathName(std::wstring & path);
 time_t FiletimeToTime(FILETIME const& ft);
 
-// Redraw timeout variables. See the comment at the bottom of SetMenuTitle for details.
+// Redraw timeout variables. See the comment above ScheduleMenuRedraw for details.
 const DWORD kMenuRedrawTimeout = 100;
 UINT_PTR redrawTimerId = NULL;
 CefRefPtr<CefBrowser> redrawBrowser;


### PR DESCRIPTION
This fixes menu drawing performance for `RemoveMenu()` and `RemoveMenuItem()` in the same way that pull request https://github.com/adobe/brackets-shell/pull/377 fixed it for `AddMenu()`.

I noticed this issue when reviewing pull request https://github.com/adobe/brackets/pull/6334.
