### PR TITLE
[REVIEW-ONLY] Implement node-module add-on for native Windows file watching

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -100,7 +100,7 @@ module.exports = function (grunt) {
                             "locales/**",
                             "node-core/**",
                             "Brackets.exe",
-                            "Brackets-node.exe",
+                            "node.exe",
                             "cef.pak",
                             "devtools_resources.pak",
                             "icudt.dll",

--- a/appshell.gyp
+++ b/appshell.gyp
@@ -103,7 +103,7 @@
             {
               # Copy node executable to the output directory
               'destination': '<(PRODUCT_DIR)',
-              'files': ['deps/node/Brackets-node.exe'],
+              'files': ['deps/node/node.exe'],
             },
             {
               # Copy node server files to the output directory

--- a/appshell/config.h
+++ b/appshell/config.h
@@ -36,7 +36,7 @@
 #define WINDOW_TITLE APP_NAME
 
 // Paths for node resources are relative to the location of the appshell executable
-#define NODE_EXECUTABLE_PATH "Brackets-node.exe"
+#define NODE_EXECUTABLE_PATH "node.exe"
 #define NODE_CORE_PATH "node-core"
 #define FIRST_INSTANCE_MUTEX_NAME	(APP_NAME L".Shell.Instance")
 #endif

--- a/tasks/setup.js
+++ b/tasks/setup.js
@@ -255,7 +255,7 @@ module.exports = function (grunt) {
         grunt.file.mkdir("deps/node");
         
         // copy node.exe to Brackets-node
-        grunt.file.copy(exeFile,  "deps/node/Brackets-node.exe");
+        grunt.file.copy(exeFile,  "deps/node/node.exe");
         
         // unzip NPM
         unzip(npmFile, "deps/node").then(function () {


### PR DESCRIPTION
Fixes brackets [issue #6551](https://github.com/adobe/brackets/issues/6551)\- "[File Watchers] Can not externally rename a directory with subfolders on Windows"

Requires associated [pull request #6673](https://github.com/adobe/brackets/pull/6673) from brackets repo.

Calling a native node-module add-on in Windows requires that the node process be named "node.exe", rather than our renamed "Brackets-node.exe".  This change reverts our previous renaming so that we ship with "node.exe" instead.
