### PR TITLE
Implement node-module add-on for native Windows file watching

### DIFF
--- a/appshell/mac/Info.plist
+++ b/appshell/mac/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>0.37.0</string>
+	<string>0.36.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.37.0</string>
+	<string>0.36.0</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/appshell/version.rc
+++ b/appshell/version.rc
@@ -32,7 +32,7 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 //
 
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION    	0,37,0,0
+FILEVERSION    	0,36,0,0
 /* PRODUCTVERSION 	1,0,0,0 */
 FILEOS         	VOS__WINDOWS32
 FILETYPE       	VFT_APP
@@ -43,7 +43,7 @@ BEGIN
         BEGIN
             VALUE "CompanyName",      "brackets.io\0"
             VALUE "FileDescription",  "\0"
-            VALUE "FileVersion",      "Sprint 37\0"
+            VALUE "FileVersion",      "Sprint 36\0"
             VALUE "ProductName",      APP_NAME "\0"
             VALUE "ProductVersion",   "\0"
             VALUE "LegalCopyright",   "(c) 2012 Adobe Systems, Inc.\0"

--- a/installer/mac/buildInstaller.sh
+++ b/installer/mac/buildInstaller.sh
@@ -2,7 +2,7 @@
 
 # config
 releaseName="Brackets"
-dmgName="${releaseName} Sprint 37"
+dmgName="${releaseName} Sprint 36"
 format="bzip2"
 encryption="none"
 tmpLayout="./dropDmgConfig/layouts/tempLayout"

--- a/installer/win/brackets-win-install-build.xml
+++ b/installer/win/brackets-win-install-build.xml
@@ -11,7 +11,7 @@ default="build.mul">
   <!-- Product & version labeling -->
   <!-- See also: product name definitions in Brackets_<locale>.wxl -->
   <property name="product.shortname" value="Brackets"/>
-  <property name="product.sprint.number" value="37"/>
+  <property name="product.sprint.number" value="36"/>
   <property name="product.version.number" value="0.${product.sprint.number}"/>
   <property name="product.version.name" value="Sprint ${product.sprint.number}"/>
   <property name="product.fullname" value="Brackets ${product.version.name}"/>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "Brackets-Shell",
-    "version": "0.37.0-0",
+    "version": "0.36.0-0",
     "homepage": "http://brackets.io",
     "issues": {
         "url": "http://github.com/adobe/brackets-shell/issues"


### PR DESCRIPTION
Fixes brackets [issue #6551](https://github.com/adobe/brackets/issues/6551)\- "[File Watchers] Can not externally rename a directory with subfolders on Windows"

Requires associated [pull request #6686](https://github.com/adobe/brackets/pull/6686) from brackets repo.

Calling a native node-module add-on in Windows requires that the node process be named "node.exe", rather than our renamed "Brackets-node.exe".  This change reverts our previous renaming so that we ship with "node.exe" instead.

NOTE: this pull request against the `release` branch replaces the earlier PR #412 against `master`.
