### PR TITLE
Ensure that filenames returned when allowMultipleSelection = false are properly canonicalized 

### DIFF
--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -543,7 +543,9 @@ int32 ShowOpenDialog(bool allowMultipleSelection,
 
             } else {
                 // If multiple files are not allowed, add the single file
-                selectedFiles->SetString(0, szFile);
+                std::wstring filePath(szFile);
+                ConvertToUnixPath(filePath);
+                selectedFiles->SetString(0, filePath);
             }
         }
     }


### PR DESCRIPTION
- Fixes https://github.com/adobe/brackets/issues/6840
