### PR TITLE
[REVIEW ONLY] Fix brackets issue #2872- "Windows: Brackets may fail to launch on a very clean OS image"

### DIFF
--- a/installer/win/Brackets.wxs
+++ b/installer/win/Brackets.wxs
@@ -104,7 +104,7 @@
         
         <!-- add MSVCRT merge modules -->
         <DirectoryRef Id="TARGETDIR">
-            <Merge Id="VCRedist" SourceFile="C:\Program Files\Microsoft SDKs\Windows\v7.0\Redist\VC\microsoft.vcxx.crt.x86_msm.msm" DiskId="1" Language="0"/>
+            <Merge Id="VCRedist" SourceFile="$(env.CommonProgramFiles)\Merge Modules\Microsoft_VC100_CRT_x86.msm" DiskId="1" Language="0"/>
         </DirectoryRef>
 
         <Feature Id="VCRedist" Title="Visual C++ 8.0 Runtime" AllowAdvertise="no" Display="hidden" Level="1">


### PR DESCRIPTION
Fix brackets [issue #2872](https://github.com/adobe/brackets/issues/2872)\- "Windows: Brackets may fail to launch on a very clean OS image"

Adds Microsoft C runtime library merge module to the WiX script used to produce the Windows installer .msi.
