### PR TITLE
Added implementation for realpath in GetFileInfo

### DIFF
--- a/appshell/appshell_extensions_gtk.cpp
+++ b/appshell/appshell_extensions_gtk.cpp
@@ -327,9 +327,7 @@ int GetFileInfo(ExtensionString filename, uint32& modtime, bool& isDir, double& 
     isDir = S_ISDIR(buf.st_mode);
     size = (double)buf.st_size;
     
-    // TODO: Implement realPath. If "filename" is a symlink, realPath should be the actual path
-    // to the linked object.
-    realPath = "";
+    realPath = realpath(filename.c_str(), NULL);
     
     return NO_ERROR;
 }


### PR DESCRIPTION
Expands symbolic links in GetFileInfo for gtk/linux hosts using posix realpath function

Required for brackets-git plugin to work properly in linux environments that use symlinks and completes GetFileInfo on these platforms. Probably makes sense to add this to the mac implementation as well but the windows implementation would get nothing from it. 
