### PR TITLE
show error stack in console on uncaught exceptions

### DIFF
--- a/appshell/node-core/Launcher.js
+++ b/appshell/node-core/Launcher.js
@@ -77,6 +77,9 @@ maxerr: 50, node: true */
      */
     function uncaughtExceptionHandler() {
         var args = Array.prototype.slice.call(arguments, 0);
+        args = args.map(function (arg) {
+            return arg instanceof Error ? arg.stack : arg;
+        });
         args.unshift("[Launcher] uncaught exception at top level, exiting.");
         Logger.error.apply(null, args);
         exit();


### PR DESCRIPTION
this will show something like this

```
[node-error 4:01:19 PM] [Launcher] uncaught exception at top level, exiting. TypeError: undefined is not a function
    at C:\Users\martinz\AppData\Roaming\Brackets\extensions\user\zaggino.brackets-git\src\Domains\processUtils.js:16:13
    at ChildProcess.exithandler (child_process.js:538:7)
    at ChildProcess.EventEmitter.emit (events.js:99:17)
    at maybeClose (child_process.js:638:16)
    at Process._handle.onexit (child_process.js:680:5)
```

on uncaught exceptions in Brackets console, instead of this

```
[node-error 4:01:19 PM] [Launcher] uncaught exception at top level, exiting. TypeError: undefined is not a function
```
