### PR TITLE
Adding VS 2013 compile support

### DIFF
--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -425,7 +425,9 @@ int32 ShowOpenDialog(bool allowMultipleSelection,
         OSVERSIONINFO osvi;
         memset(&osvi, 0, sizeof(OSVERSIONINFO));
         osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
+#pragma warning (disable: 4996)
         if (GetVersionEx(&osvi) && (osvi.dwMajorVersion >= 6)) {
+#pragma warning (default: 4996)
             // for Vista or later, use the MSDN-preferred implementation of the Open File dialog in pick folders mode
             IFileDialog *pfd;
             if (SUCCEEDED(CoCreateInstance(CLSID_FileOpenDialog, NULL, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&pfd)))) {

--- a/appshell/cef_dark_aero_window.cpp
+++ b/appshell/cef_dark_aero_window.cpp
@@ -53,7 +53,9 @@ HINSTANCE CDwmDLL::LoadLibrary()
         OSVERSIONINFO osvi;
         ZeroMemory(&osvi, sizeof(OSVERSIONINFO));
         osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
+#pragma warning (disable: 4996)
         GetVersionEx(&osvi);
+#pragma warning (default: 4996)
         if ((osvi.dwMajorVersion > 5) || ((osvi.dwMajorVersion == 5) && (osvi.dwMinorVersion >= 1) ))
         {
             mhDwmDll = ::LoadLibrary(TEXT("dwmapi.dll"));

--- a/scripts/build_projects.bat
+++ b/scripts/build_projects.bat
@@ -2,12 +2,17 @@
 :: This file should *not* be called directly. It is called by the build.sh script.
 ECHO OFF
 
+IF DEFINED VS120COMNTOOLS GOTO VS2013
 IF DEFINED VS110COMNTOOLS GOTO VS2012
 IF DEFINED VS100COMNTOOLS GOTO VS2010
 
 :VSNotInstalled
-ECHO Visual Studio 2010 or 2012 must be installed.
+ECHO Visual Studio 2010, 2012 or 2013 must be installed.
 GOTO Exit
+
+:VS2013
+call "%VS120COMNTOOLS%/vsvars32.bat"
+GOTO Build
 
 :VS2012
 call "%VS110COMNTOOLS%/vsvars32.bat"


### PR DESCRIPTION
Adds compilation support for VS 2013 tools. As some Windows functions are obsolete on newer Windows I have disabled the warnings with `#pragma`s.