### PR TITLE
Fix Crash when open file via OS while File > Open dialog is left open (adobe/brackets#7752)

### DIFF
--- a/appshell/cefclient_mac.mm
+++ b/appshell/cefclient_mac.mm
@@ -691,17 +691,6 @@ extern NSMutableArray* pendingOpenFiles;
     ClientApplication * clientApp = (ClientApplication *)theApplication;
     NSWindow* targetWindow = [clientApp findTargetWindow];
     if (targetWindow) {
-      // if files are droppend and the Open/Save Dialog is visible, then browser is NULL
-      // find the main window. If this is not the main window, then it's a modal dialog like open or save. The main
-      // window has a reference to the CerBrowser instance
-      // This fixes https://github.com/adobe/brackets/issues/7752
-      if (![targetWindow isMainWindow]) {
-          targetWindow = [targetWindow parentWindow];
-      }
-
-      // move App window to front
-      [targetWindow orderFront: self];
-        
       CefRefPtr<CefBrowser> browser = ClientHandler::GetBrowserForNativeWindow(targetWindow);
       NSUInteger count = [filenames count];
       if (count) {

--- a/appshell/client_handler.cpp
+++ b/appshell/client_handler.cpp
@@ -354,8 +354,12 @@ void ClientHandler::SendOpenFileCommand(CefRefPtr<CefBrowser> browser, const Cef
   // FIXME: Use SendJSCommand once it supports parameters
   std::string cmd = "require('command/CommandManager').execute('file.openDroppedFiles'," + fileArrayStr + ")";
 
-  browser->GetMainFrame()->ExecuteJavaScript(CefString(cmd.c_str()),
+  // if files are droppend and the Open Dialog is visible, then browser is NULL
+  // This fixes https://github.com/adobe/brackets/issues/7752
+  if (browser) {
+    browser->GetMainFrame()->ExecuteJavaScript(CefString(cmd.c_str()),
                                 browser->GetMainFrame()->GetURL(), 0);
+  }
 }
 
 void ClientHandler::DispatchCloseToNextBrowser()


### PR DESCRIPTION
This bug fixes https://github.com/adobe/brackets/issues/7752.

Before we open any file that was either dropped or send to Brackets via "Open With...", the pointer to the browser instance will be checked to make sure it is not null.
