### PR TITLE
Create extensions folders on Linux

### DIFF
--- a/installer/linux/archive/install.sh
+++ b/installer/linux/archive/install.sh
@@ -5,6 +5,9 @@ curDir=$(pwd)
 
 mkdir -p ~/.local/share/applications
 mkdir -p ~/.local/bin
+mkdir -p ~/.config/Brackets/extensions/dev
+mkdir -p ~/.config/Brackets/extensions/disabled
+mkdir -p ~/.config/Brackets/extensions/user
 
 # Setup our brackets.desktop file.
 cp brackets.desktop temp.desktop


### PR DESCRIPTION
Link adobe/brackets#8024

I simply referred to the `mkdir` syntax above (after looking up what -p meant) and pulled the folder path from `uninstall.sh` in the same folder as this.
