### PR TITLE
Fix Issue #6073- "[PM] Installer steals file associations with no warning (for a few users)"

### DIFF
--- a/installer/win/Brackets.wxs
+++ b/installer/win/Brackets.wxs
@@ -58,7 +58,6 @@
                                Value="!(loc.ProductName) FileExt" Name=".$(var.filetype)" Type="string" />
 
                 <!-- associate each supported filetype with application -->
-                <RegistryValue Root="HKCR" Key=".$(var.filetype)" Value="text" Name="PerceivedType" Type="string" />
                 <RegistryValue Root="HKCR" Key=".$(var.filetype)\OpenWithProgids" Value=""
                                Name="!(loc.ProductName) FileExt" Type="string" />
             <?endforeach?>


### PR DESCRIPTION
Fix for Brackets [Issue #6073](https://github.com/adobe/brackets/issues/6073)\- "[PM] Installer steals file associations with no warning (for a few users)".

Removed the installing of registry key `PerceivedType` which appears to be overriding the associated icon set by other apps on Windows 7.

See [@SAPlayer's comment here](https://github.com/adobe/brackets/issues/6073#issuecomment-46685036) for more details.

Note: this only affects Windows 7 apparently.  The reported problem does not exist in Windows 8.x.
