### PR TITLE
Add keywords to improve search on Ubuntu

### DIFF
--- a/installer/linux/debian/brackets.desktop
+++ b/installer/linux/debian/brackets.desktop
@@ -5,3 +5,4 @@ Categories=Development
 Exec=/opt/brackets/brackets %U
 Icon=brackets
 MimeType=text/html;
+Keywords=Text;Editor;Write;Web;Development;


### PR DESCRIPTION
Allows searching for the keywords in Ubuntu dash.

Fixes adobe/brackets#8342, also adds a few more tags (other than 'editor'). Can easily be expanded to more tags, currently includes (not case sensitive) `Editor`, `Text`, `Web`, `Development`.

Seems to work for all the tags, although sometimes the search in Ubuntu's Unity dash seems to break. This breaking isn't something that Brackets is responsible for, as far as I can tell (no editors show up, and with this line removed, they still don't show up in some cases). These cases appear to be random, no reason that I could find.
