### PR TITLE
appshell.rc will have Release 0.xx instead Release xx

### DIFF
--- a/appshell/version.rc
+++ b/appshell/version.rc
@@ -43,7 +43,7 @@ BEGIN
         BEGIN
             VALUE "CompanyName",      "brackets.io\0"
             VALUE "FileDescription",  "\0"
-            VALUE "FileVersion",      "Release 44\0"
+            VALUE "FileVersion",      "Release 0.44\0"
             VALUE "ProductName",      APP_NAME "\0"
             VALUE "ProductVersion",   "\0"
             VALUE "LegalCopyright",   "(c) 2012 Adobe Systems, Inc.\0"

--- a/tasks/set-release.js
+++ b/tasks/set-release.js
@@ -92,7 +92,7 @@ module.exports = function (grunt) {
         );
         text = safeReplace(
             text,
-            /(Release )([0-9]+)/,
+            /(Release 0\.)([0-9]+)/,
             "$1" + release
         );
         grunt.file.write(versionRcPath, text);


### PR DESCRIPTION
 This makes it more consistent across all files where we use the release build number
