### PR TITLE
Hide OnLoadError message from end users

### DIFF
--- a/appshell/client_handler.cpp
+++ b/appshell/client_handler.cpp
@@ -181,7 +181,7 @@ void ClientHandler::OnLoadError(CefRefPtr<CefBrowser> browser,
         "    console.error(msg);" <<
         "  </script>" <<
         "</head>" <<
-        "<body><a class='debug logo' onclick='brackets.app.showDeveloperTools()'>&nbsp;</a></body></html>";
+        "<body><a class='debug logo' onclick='brackets.app.showDeveloperTools()' title='Click to view loading error in Developer Tools'>&nbsp;</a></body></html>";
   frame->LoadString(ss.str(), failedUrl);
 }
 


### PR DESCRIPTION
The shell currently displays URL loading errors to end users, it's not pretty. For example, using dev tools  `window.location.href = "unsupported://"` you'll see:

![image](https://cloud.githubusercontent.com/assets/1148713/4342843/f8025526-404a-11e4-8457-6852f60bf626.png)

This PR does 2 things: (1) use a background color that matches the title bar (and working set bgcolor) and (2) suppress the error in an HTML comment `<!-- -->` for developers to find in dev tools:

![image](https://cloud.githubusercontent.com/assets/1148713/4342858/1b6d9962-404b-11e4-815c-2ab99bb425a0.png)

Note: Pretend there's comment markup in that last screenshot.
