### PR TITLE
Proper fix for "Show in OS" for Linux.

### DIFF
--- a/appshell.gyp
+++ b/appshell.gyp
@@ -239,7 +239,7 @@
             }
           ],
           'cflags': [
-            '<!@(<(pkg-config) --cflags gtk+-2.0 gthread-2.0 dbus-glib-1)',
+            '<!@(<(pkg-config) --cflags gtk+-2.0 gthread-2.0 glib-2.0)',
             '<(march)',
           ],
           'include_dirs': [
@@ -283,12 +283,12 @@
           ],
           'link_settings': {
             'ldflags': [
-              '<!@(<(pkg-config) --libs-only-other gtk+-2.0 gthread-2.0 dbus-glib-1)',
+              '<!@(<(pkg-config) --libs-only-other gtk+-2.0 gthread-2.0 glib-2.0)',
               '-Wl,-rpath,\$$ORIGIN/lib',
               '<(march)'
             ],
             'libraries': [
-              '<!@(<(pkg-config) --libs-only-l gtk+-2.0 gthread-2.0 dbus-glib-1)',
+              '<!@(<(pkg-config) --libs-only-l gtk+-2.0 gthread-2.0 glib-2.0)',
               '$(BUILDTYPE)/libcef.so',
               'appshell_extensions_js.o',
             ],
@@ -328,7 +328,7 @@
       'conditions': [
         ['OS=="linux"', {
           'cflags': [
-          '<!@(<(pkg-config) --cflags gtk+-2.0 gthread-2.0 dbus-glib-1)',
+          '<!@(<(pkg-config) --cflags gtk+-2.0 gthread-2.0 glib-2.0)',
           '<(march)',
           ],
           'default_configuration': 'Release',


### PR DESCRIPTION
Proper fix for "Show in OS" for Linux.

Now using an IPC method call (FileManager1.ShowItems) to show the file (highlighted) in its directory.
Also updated the appshell.gyp file.
Using the new DBus bindings which are provided by the GLib library (requires libglib-2.0 version 2.26 and up), so this no longer requires the old binding library (libdbus-glib-1).

If for some reason the above solution fails, the fallback behavior is to just open the directory containing the file (without the file being highlighted). This is done by calling gtk_show_uri() on the file's parent directory.

This is for https://trello.com/c/RF1ddQGK/898-linux-show-in-os-for-selected-file
