### PR TITLE
Enable Yosemite Native Traffic Lights on OSX 10.10

### DIFF
--- a/appshell/cefclient_mac.mm
+++ b/appshell/cefclient_mac.mm
@@ -222,9 +222,9 @@ extern NSMutableArray* pendingOpenFiles;
 }
 
 -(BOOL)isRunningOnYosemite {
-    // this API returns nil prior to Yosemite
-    NSDictionary * dict = [NSDictionary dictionaryWithContentsOfFile:@"/System/Library/CoreServices/SystemVersion.plist"];
-    return dict != nil;
+    NSDictionary* dict = [NSDictionary dictionaryWithContentsOfFile:@"/System/Library/CoreServices/SystemVersion.plist"];
+    NSString* version =  [dict objectForKey:@"ProductVersion"];
+    return [version hasPrefix:@"10.10"];
 }
 
 - (BOOL)isFullScreenSupported {

--- a/appshell/client_handler_mac.mm
+++ b/appshell/client_handler_mac.mm
@@ -166,9 +166,9 @@ void ClientHandler::CloseMainWindow() {
 }
 
 -(BOOL)isRunningOnYosemite {
-    // this API returns nil prior to Yosemite
-    NSDictionary * dict = [NSDictionary dictionaryWithContentsOfFile:@"/System/Library/CoreServices/SystemVersion.plist"];
-    return dict != nil;
+    NSDictionary* dict = [NSDictionary dictionaryWithContentsOfFile:@"/System/Library/CoreServices/SystemVersion.plist"];
+    NSString* version =  [dict objectForKey:@"ProductVersion"];
+    return [version hasPrefix:@"10.10"];
 }
 
 - (BOOL)isFullScreenSupported {


### PR DESCRIPTION
This is for https://github.com/adobe/brackets/issues/9608
- Use system traffic lights on Yosemite
- Hide the Full Screen Button since the Native Traffic Lights do this
- Use custom traffic lights on 10.8, 10.9
