### PR TITLE
Add a fix for Surface Pro users who auto hide their taskbar

### DIFF
--- a/appshell/cef_dark_aero_window.cpp
+++ b/appshell/cef_dark_aero_window.cpp
@@ -155,7 +155,10 @@ namespace WindowsTaskBar
         RECT tbOther;
         BOOL intersection = ::IntersectRect(&tbOther, &info.rcMonitor, &bar.rc);
 
-        return ((dwStyle & WS_EX_TOPMOST) && intersection);
+        // Short-circuit if there's only 1 monitor and assume it intersects
+        bool singleMonitor = (::GetSystemMetrics(SM_CMONITORS) == 1);
+
+        return ((dwStyle & WS_EX_TOPMOST) && (singleMonitor || intersection));
     }
 
     // API


### PR DESCRIPTION
This is for https://github.com/adobe/brackets/issues/7555

This update fixes a problem for Surface Pro users with auto-hide taskbars that @bchintx found while testing on a 1st Gen Surface Pro.  

This may need further development as the underlying cause isn't clear but, because I don't have a Surface Pro to test with and it isn't very likely that a Surface Pro user is going to run Windows 8.1 with more than one monitor, this solution should be sufficient.  

@bchintx confirmed this so he should reconfirm with an official installer build after this has been merged.

@redmunds can you do a quick code review and let me know what you think and merge it if you think it's good to go?

I'll let @bchintx know when he can test it again.
