### PR TITLE
Support cmd-a, c, v, x for text input in native dialogs like file open, save

### DIFF
--- a/appshell/cefclient_mac.mm
+++ b/appshell/cefclient_mac.mm
@@ -97,7 +97,7 @@ extern NSMutableArray* pendingOpenFiles;
         theSelector = NSSelectorFromString(@"selectAll:");
       } else if (keyChar == 'z'){
         theSelector = NSSelectorFromString(@"undo:");
-      } else if (keyChar == 'y'){
+      } else if (keyChar == 'Z'){
         theSelector = NSSelectorFromString(@"redo:");
       }
       if (theSelector != nil) {


### PR DESCRIPTION
Addresses this bug:
1. File -> Open.
2. Type in some text in the file open dialog (in the search field in Yosemite or filename text input)

Actual: Try Cmd-A, C, X, V - they do not work.
Expected: They work.
