### PR TITLE
Fix for loading the icon list in Linux

### DIFF
--- a/appshell/cefclient_gtk.cpp
+++ b/appshell/cefclient_gtk.cpp
@@ -195,14 +195,18 @@ int main(int argc, char* argv[]) {
   // Set window icon
   std::vector<std::string> icons(APPICONS, APPICONS + sizeof(APPICONS) / sizeof(APPICONS[0]) );
   GList *list = NULL;
-  for (int i = 0; i < icons.size(); ++i) {
-    std::string path = icons[i];
-    
-    GdkPixbuf *icon = gdk_pixbuf_new_from_file(path.c_str(), NULL);
-    if (!icon)
-       continue;
-    
-    list = g_list_append(list, icon);
+  for(int i = 0; i < icons.size(); ++i) {
+      GError *error = NULL;
+      std::string running_dir = AppGetRunningDirectory();
+      gchar *iconpath = g_strdup_printf("%s/%s", running_dir.c_str(), icons[i].c_str());
+      GdkPixbuf *icon = gdk_pixbuf_new_from_file(iconpath, &error);
+      g_free(iconpath);
+      if (!icon) {
+          g_printerr("Unable to create GdkPixbuf object. Reason: %s\n", error->message);
+          g_error_free(error);
+          continue;
+      }
+      list = g_list_append(list, icon);
   }
 
   window = gtk_window_new(GTK_WINDOW_TOPLEVEL);


### PR DESCRIPTION
This commit fixes a couple of things:
    1. The list of icons was using relative paths.
    2. If the icons could not be loaded, the error was ignored without a warning.

For 1) I am prefixing the icon paths with the directory where the Brackets executable resides (since the icons are there, too).
One might think that the paths are relative to the aforementioned directory, except that is only true if Brackets is started from the launcher. If I start Brackets from the command line (or if I specify another initial working dir), Brackets fails to load the icons.
On top of that, no warning is issued to the user, making this hard to trace as my window manager cached the icons (so for testing I had to rename the executable, too). Which leads me to 2), now I'm issuing a warning if Brackets fails to load any of the icons.
The bug was originally pointed out to me by another user - @orschiro on github.

Here's what it looks like:
![icon_bug_cropped](https://cloud.githubusercontent.com/assets/2711709/4777249/f16d377e-5bcc-11e4-8359-191cc9b9f9ec.png)

To reproduce the issue:
1. Start a terminal
2. cd ~/
3. sudo cp /opt/brackets/Brackets /opt/brackets/test1
4. /opt/brackets/test1

Running the copy of the Brackets executable from 4) is necessary in order to bypass any cache the window manager might have.
