### PR TITLE
Fix canvas rendering bug by disabling 2d canvas acceleration

### DIFF
--- a/appshell/cefclient_mac.mm
+++ b/appshell/cefclient_mac.mm
@@ -625,7 +625,11 @@ extern NSMutableArray* pendingOpenFiles;
   CefBrowserSettings settings;
 
   settings.web_security = STATE_DISABLED;
-  settings.accelerated_compositing = STATE_DISABLED;
+
+  CefRefPtr<CefCommandLine> cmdLine = AppGetCommandLine();
+  if (cmdLine->HasSwitch(cefclient::kAcceleratedCompositingDisabled)) {
+    settings.accelerated_compositing = STATE_DISABLED;
+  }
 
 #ifdef DARK_INITIAL_PAGE
   // Avoid white flash at startup or refresh by making this the default


### PR DESCRIPTION
Mac only fix behind a command line flag:

```
open ./xcodebuild/Release/Brackets.app --args --accelerated-compositing-disabled
```

Frankly, I'm going off of a best guess at this point to address some canvas rendering bugs that are similar to this chrome 29 [bug](https://code.google.com/p/chromium/issues/detail?id=278940), see [comment](https://code.google.com/p/chromium/issues/detail?id=278940#c31) and related [bug](https://code.google.com/p/chromium/issues/detail?id=280153) with the tip to disable 2d accelerated canvas.

Another possible point of reference: http://magpcss.org/ceforum/viewtopic.php?f=10&t=181&p=622&hilit=accelerated+2d+canvas+disabled#p622.
