### PR TITLE
Restoring the QUIT sequence on linux to that of CefClient

### DIFF
--- a/appshell/cefclient_gtk.cpp
+++ b/appshell/cefclient_gtk.cpp
@@ -58,7 +58,6 @@ static gboolean HandleQuit(int signatl) {
     g_handler->SendJSCommand(g_handler->GetBrowser(), FILE_CLOSE_WINDOW, callback);
     return TRUE;
   }
-  destroy();
 }
 
 bool FileExists(std::string path) {


### PR DESCRIPTION
Removing the destroy() function call, which in turn calls
CefQuitMessageLoop() as the right place to call this is inside
ClientHandler::OnBeforeClose().
