### PR TITLE
Support initialDirectory and title in Linux' showOpenDialog

### DIFF
--- a/appshell/appshell_extensions_gtk.cpp
+++ b/appshell/appshell_extensions_gtk.cpp
@@ -164,15 +164,21 @@ int32 ShowOpenDialog(bool allowMultipleSelection,
                      CefRefPtr<CefListValue>& selectedFiles)
 {
     GtkWidget *dialog;
-    const char* dialog_title = chooseDirectory ? "Open Directory" : "Open File";
+    // const char* dialog_title = chooseDirectory ? "Open Directory" : "Open File";
     GtkFileChooserAction file_or_directory = chooseDirectory ? GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER : GTK_FILE_CHOOSER_ACTION_OPEN ;
-    dialog = gtk_file_chooser_dialog_new (dialog_title,
+    dialog = gtk_file_chooser_dialog_new (title.c_str(),
                   NULL,
                   file_or_directory,
                   GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
                   GTK_STOCK_OPEN, GTK_RESPONSE_ACCEPT,
                   NULL);
     
+    if (!initialDirectory.empty())
+    {
+        ExtensionString folderURI = std::string("file:///") + initialDirectory;
+        gtk_file_chooser_set_current_folder_uri (GTK_FILE_CHOOSER (dialog), folderURI.c_str());
+    }
+
     if (gtk_dialog_run (GTK_DIALOG (dialog)) == GTK_RESPONSE_ACCEPT)
     {
         char *filename;

--- a/appshell/appshell_extensions_gtk.cpp
+++ b/appshell/appshell_extensions_gtk.cpp
@@ -164,7 +164,6 @@ int32 ShowOpenDialog(bool allowMultipleSelection,
                      CefRefPtr<CefListValue>& selectedFiles)
 {
     GtkWidget *dialog;
-    // const char* dialog_title = chooseDirectory ? "Open Directory" : "Open File";
     GtkFileChooserAction file_or_directory = chooseDirectory ? GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER : GTK_FILE_CHOOSER_ACTION_OPEN ;
     dialog = gtk_file_chooser_dialog_new (title.c_str(),
                   NULL,


### PR DESCRIPTION
For https://github.com/adobe/brackets/issues/10297
I weren't able to build this due to various errors (in a Ubuntu 14.10 VM), not even on top of the `linux-1547` branch.

I also don't know what to do with `fileTypes` - it currently doesn't work either.