### PR TITLE
Add -lpthread to LIBS (libraries).

### DIFF
--- a/appshell.gyp
+++ b/appshell.gyp
@@ -514,6 +514,7 @@
             ],
             'libraries': [
               '$(shell <(pkg-config) --libs-only-l <(gtk_packages))',
+              '-lpthread',
             ],
           },
         },


### PR DESCRIPTION
@ingorichter, this is to fix properly the linker error that both I and @jasonsanjose [have been hitting](https://github.com/adobe/brackets-shell/pull/489#issuecomment-65870653). It might be specific to Ubuntu 14.04, but should be harmless to other versions/distributions.