### PR TITLE
Fix crash on quit in CEF 2171 linux

### DIFF
--- a/appshell/appshell_extensions_gtk.cpp
+++ b/appshell/appshell_extensions_gtk.cpp
@@ -535,12 +535,12 @@ void MoveFileOrDirectoryToTrash(ExtensionString filename, CefRefPtr<CefBrowser> 
 
 void CloseWindow(CefRefPtr<CefBrowser> browser)
 {
-    if (browser.get()) {
-        isReallyClosing = true;
-        GtkWidget* widget = gtk_widget_get_toplevel (browser->GetHost()->GetWindowHandle());
-        browser->GetHost()->CloseBrowser(true);
-        gtk_signal_emit_by_name(GTK_OBJECT(widget), "delete_event"); 
-    }
+  if (browser.get()) {
+    isReallyClosing = true;
+
+    GtkWidget* hwnd = gtk_widget_get_toplevel (GTK_WIDGET(g_handler->GetMainHwnd() ));
+    browser->GetHost()->CloseBrowser(true);
+    gtk_signal_emit_by_name(GTK_OBJECT(hwnd), "delete_event");
   }
 }
 


### PR DESCRIPTION
Note: This is a merge into `jasonsanjose/cef_2171_linux`

Merge work from PR #458 from @nathanial. Update code to work with linux 2171.

@nethip can you try this and see if it fixes the bug? It seems to work better for me. It only crashed on quit once after a few dozen tries where the previous code crashed pretty consistently in my VM.
