### PR TITLE
Changing Permission for xdg-open file to 755. xdg-open needs to be execu...

### DIFF
--- a/installer/linux/build_archive.sh
+++ b/installer/linux/build_archive.sh
@@ -5,6 +5,7 @@
 chmod 755 debian/package-root/opt/brackets/brackets
 chmod 755 debian/package-root/opt/brackets/Brackets
 chmod 755 debian/package-root/opt/brackets/Brackets-node
+chmod 755 debian/package-root/opt/brackets/www/LiveDevelopment/MultiBrowserImpl/launchers/node/node_modules/open/vendor/xdg-open
 
 # set permissions on subdirectories
 find debian -type d -exec chmod 755 {} \;

--- a/installer/linux/build_installer.sh
+++ b/installer/linux/build_installer.sh
@@ -5,6 +5,7 @@
 chmod 755 debian/package-root/opt/brackets/brackets
 chmod 755 debian/package-root/opt/brackets/Brackets
 chmod 755 debian/package-root/opt/brackets/Brackets-node
+chmod 755 debian/package-root/opt/brackets/www/LiveDevelopment/MultiBrowserImpl/launchers/node/node_modules/open/vendor/xdg-open
 chmod 755 debian/package-root/DEBIAN/prerm
 chmod 755 debian/package-root/DEBIAN/postrm
 chmod 755 debian/package-root/DEBIAN/postinst


### PR DESCRIPTION
...table otherwise browser does not launch for MultiBrowser Preview. grunt-contrib-copy does not preserve permissions so setting it explicitly for linux. Issue - https://github.com/adobe/brackets/issues/10229.