### PR TITLE
Abose/win hi dpi hdc leak

### DIFF
--- a/appshell/cef_window.cpp
+++ b/appshell/cef_window.cpp
@@ -359,5 +359,6 @@ UINT cef_window::GetDPIScalingX() const
     float lpx = dc ? GetDeviceCaps(dc,LOGPIXELSX):DEFAULT_WINDOWS_DPI ;
     //scale factor as it would look in a default(96dpi) screen. the default will be always 96 logical DPI when scaling is applied in windows.
     //see. https://msdn.microsoft.com/en-us/library/ms701681(v=vs.85).aspx 
+	ReleaseDC(dc);
     return (lpx/DEFAULT_WINDOWS_DPI)*100; 
 }

--- a/appshell/cef_window.cpp
+++ b/appshell/cef_window.cpp
@@ -359,6 +359,6 @@ UINT cef_window::GetDPIScalingX() const
     float lpx = dc ? GetDeviceCaps(dc,LOGPIXELSX):DEFAULT_WINDOWS_DPI ;
     //scale factor as it would look in a default(96dpi) screen. the default will be always 96 logical DPI when scaling is applied in windows.
     //see. https://msdn.microsoft.com/en-us/library/ms701681(v=vs.85).aspx 
-	ReleaseDC(dc);
+    ReleaseDC(dc);
     return (lpx/DEFAULT_WINDOWS_DPI)*100; 
 }

--- a/appshell/cef_window.h
+++ b/appshell/cef_window.h
@@ -173,7 +173,7 @@ public:
     HDC GetDC() const
     { return ::GetDC(mWnd); }
 
-    int ReleaseDC(HDC dc)
+    int ReleaseDC(HDC dc) const
     { return ::ReleaseDC(mWnd, dc); }
 
     BOOL SetWindowPos(cef_window* insertAfter, int x, int y, int cx, int cy, UINT uFlags) 


### PR DESCRIPTION
Fix for issue.  adobe/brackets/issues/10707:
"The function below doesn't release the drawing context it uses to get the Device Capabilities which could lead to instability -- Windows will allocate memory for new ones (unless you change the CEF Window class to use a shared DC)."

Releasing dc after calculating DPI scaling.