### PR TITLE
Fix for launching Brackets from command line (Win Only)

### DIFF
--- a/appshell/cefclient_win.cpp
+++ b/appshell/cefclient_win.cpp
@@ -89,21 +89,43 @@ bool GetFullPath(const std::wstring& path, std::wstring& oFullPath)
   DWORD retval;
   TCHAR  buffer[MAX_UNC_PATH] = TEXT(""); 
   TCHAR  buf[MAX_UNC_PATH]    = TEXT(""); 
- 
-  // Retrieve the full path name for a file. 
-  // The file does not need to exist.
-  retval = GetFullPathName( path.c_str(),
-                            MAX_UNC_PATH,
-                            buffer,
-                            NULL );
 
-  if (retval == 0)  {
+  if(path.length() <= 0) {
     return false;
   }
-  else{
-    oFullPath = buffer;
-    return true;
+
+  if(path[0] == L'"' && path[path.length() -1] == L'"') {
+    // This is a special case where arguments are sent
+    // as quotes(e.g.:file names having spaces). In this
+    // case we first strip the quotes, get the path 
+    // and finally append the quotes to the result.
+    std::wstring normalizedPath = path;
+    normalizedPath.erase (std::remove(normalizedPath.begin(), normalizedPath.end(), L'"'), normalizedPath.end());
+
+    retval = GetFullPathName( normalizedPath.c_str(),
+                              MAX_UNC_PATH,
+                              buffer,
+                              NULL );
+    // Now add the quotes to the final string.
+    if(retval) {
+       oFullPath = L'"';
+       oFullPath = oFullPath + buffer + L'"';
+    }
+
   }
+  else {
+  
+    // Retrieve the full path name for a file. 
+    // The file does not need to exist.
+    retval = GetFullPathName( path.c_str(),
+                              MAX_UNC_PATH,
+                              buffer,
+                              NULL );
+    if(retval)
+      oFullPath = buffer;
+  }
+
+  return (retval == 0) ? false : true;
 
 }
 

--- a/appshell/cefclient_win.cpp
+++ b/appshell/cefclient_win.cpp
@@ -160,6 +160,8 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
   if (exit_code >= 0)
     return exit_code;
 
+  bool isShiftKeyDown = (GetAsyncKeyState(VK_SHIFT) & 0x8000) ? true: false;
+
   // Retrieve the current working directory.
   if (_getcwd(szWorkingDir, MAX_UNC_PATH) == NULL)
     szWorkingDir[0] = 0;
@@ -221,7 +223,7 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
   }
   else {
 	// If the shift key is not pressed, look for the index.html file 
-	if (GetAsyncKeyState(VK_SHIFT) == 0) {
+	if (!isShiftKeyDown) {
 	// Get the full pathname for the app. We look for the index.html
 	// file relative to this location.
 	wchar_t appPath[MAX_UNC_PATH];

--- a/installer/win/Brackets.wxs
+++ b/installer/win/Brackets.wxs
@@ -61,7 +61,15 @@
                 <RegistryValue Root="HKCR" Key=".$(var.filetype)\OpenWithProgids" Value=""
                                Name="!(loc.ProductName) FileExt" Type="string" />
             <?endforeach?>
-
+            
+            <!-- Add Open With Brackets to explorer's file context menu -->
+            <RegistryValue Root="HKCR" Key="*\shell\!(loc.OpenWithText)\command" Value="[INSTALLDIR]$(var.ExeName).exe &quot;%1&quot;"
+                               Type="string" />
+            
+            <!-- Add Open With Brackets to explorer's folder context menu -->
+            <RegistryValue Root="HKCR" Key="Folder\shell\!(loc.OpenWithText)\command" Value="[INSTALLDIR]$(var.ExeName).exe &quot;%1&quot;"
+                               Type="string" />
+            
             <!-- create ProgId entry -->
             <RegistryValue Root="HKLM" Key="SOFTWARE\Classes\!(loc.ProductName) FileExt\shell\open\command"
                            Value="&quot;[INSTALLDIR]$(var.ExeName).exe&quot; &quot;%1&quot;" Type="string" />

--- a/installer/win/Brackets.wxs
+++ b/installer/win/Brackets.wxs
@@ -71,11 +71,6 @@
                            Name="FriendlyAppName" Value="!(loc.ProductName)" Type="string" />
         </Component>
         
-        <!-- Update the system PATH variable  -->
-        <Component Id="UpdatePath" Guid="FD30DF6D-B6D2-4A66-9C26-37F3C1A1E921">
-            <Environment Id="PATH" Name="PATH" Value="[INSTALLDIR]" Permanent="no" Part="last" Action="set" System="yes" />
-        </Component>
-        
         <!-- Start Menu Shortcuts-->
         <UIRef Id="WixUI_MyInstallDir" />
         <UIRef Id="WixUI_ErrorProgressText" />
@@ -101,7 +96,19 @@
         <!--Setup Folder Structure -->
         <Directory Id='TARGETDIR' Name='SourceDir'>
             <Directory Id='ProgramFilesFolder'>
-                <Directory Id='INSTALLDIR' Name='!(loc.ShortProductName)'/>
+                <Directory Id='INSTALLDIR' Name='!(loc.ShortProductName)'>
+                  <Component Id="UpdatePath"
+                             Guid="1781A625-8ACB-45E7-A8BA-219D81760B2E">
+                    <CreateFolder />
+                    <Environment Id="PATH"
+                                 Action="set"
+                                 Part="last"
+                                 Name="PATH"
+                                 Permanent="no"
+                                 System="yes"
+                                 Value="[INSTALLDIR]" />
+                  </Component>
+                </Directory>
             </Directory>
             <Directory Id="ProgramMenuFolder"/>
         </Directory>
@@ -116,6 +123,7 @@
             <ComponentRef  Id='StartMenuShortcut' />
 
             <ComponentRef  Id='FileAssociations' />
+            <ComponentRef  Id="UpdatePath" />
         </Feature>                  
 
         <SetProperty Id="ARPINSTALLLOCATION" Value="[INSTALLDIR]" After="CostFinalize" />    

--- a/installer/win/Brackets.wxs
+++ b/installer/win/Brackets.wxs
@@ -71,6 +71,11 @@
                            Name="FriendlyAppName" Value="!(loc.ProductName)" Type="string" />
         </Component>
         
+        <!-- Update the system PATH variable  -->
+        <Component Id="UpdatePath" Guid="FD30DF6D-B6D2-4A66-9C26-37F3C1A1E921">
+            <Environment Id="PATH" Name="PATH" Value="[INSTALLDIR]" Permanent="no" Part="last" Action="set" System="yes" />
+        </Component>
+        
         <!-- Start Menu Shortcuts-->
         <UIRef Id="WixUI_MyInstallDir" />
         <UIRef Id="WixUI_ErrorProgressText" />

--- a/installer/win/Brackets_en-us.wxl
+++ b/installer/win/Brackets_en-us.wxl
@@ -54,4 +54,5 @@
     <String Id="ExitDialogTitle" Overridable="yes">{\WixUI_Font_BannerTitle}Completed the [ProductName] Setup Wizard</String>
     <String Id="VerifyReadyDlgInstallText" Overridable="yes">Click Install to begin, or Cancel to exit.</String>
     <String Id="VerifyReadyDlgRemoveText" Overridable="yes">Click Remove to uninstall !(loc.ShortProductName), or Cancel to exit.</String>
+    <String Id="OpenWithText" Overridable="yes">Open With !(loc.ShortProductName)</String>
 </WixLocalization>

--- a/installer/win/Brackets_fr-fr.wxl
+++ b/installer/win/Brackets_fr-fr.wxl
@@ -53,7 +53,7 @@
     <String Id="ExitDialogTitle" Overridable="yes">{\WixUI_Font_BannerTitle}Procédure de l’assistant d’installation de [ProductName] terminée</String>
     <String Id="VerifyReadyDlgInstallText" Overridable="yes">Cliquez sur Installer pour lancer la procédure ou sur Annuler pour quitter.</String>
     <String Id="VerifyReadyDlgRemoveText" Overridable="yes">Cliquez sur Supprimer pour désinstaller !(loc.ShortProductName) ou sur Annuler pour quitter.</String>
-    
+    <String Id="OpenWithText" Overridable="yes">Open With !(loc.ShortProductName)</String>
       
     <!-- these strings aren't necessarily used but they were modified by the adobe loc team after they reviewed the wix source fr-fr wxl file.
     Adding them here if it works to call multiple loc files with the light command that are part of the same culture -->


### PR DESCRIPTION
The change basically fixes the following problems. 

1) Our command line arguments were never respected as Brackets was expecting a full path and we were just passing the file names

2) Adding the install location to the PATH variable which will allow users to launch Brackets just by typing "Brackets" instead of full path like "C:\Program Files (86)\Brackets\Brackets.exe".

This is a Win only change.