### PR TITLE
Support AppGetChromeVersionString and AppGetProductVersionString on Linux

### DIFF
--- a/appshell/cefclient_gtk.cpp
+++ b/appshell/cefclient_gtk.cpp
@@ -6,6 +6,7 @@
 #include <gtk/gtk.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <sstream>
 #include <string>
 #include <sys/stat.h>
 #include "cefclient.h"
@@ -15,8 +16,11 @@
 #include "include/cef_frame.h"
 #include "include/cef_runnable.h"
 #include "client_handler.h"
+#include "config.h"
 #include "client_switches.h"
 #include "appshell_node_process.h"
+
+#include "version_linux.h"
 
 static std::string APPICONS[] = {"appshell32.png","appshell48.png","appshell128.png","appshell256.png"};
 char szWorkingDir[512];  // The current working directory
@@ -267,11 +271,17 @@ int main(int argc, char* argv[]) {
 }
 
 CefString AppGetProductVersionString() {
-  // TODO
-  return CefString("");
+  std::string s = APP_NAME "/" APP_VERSION;
+  CefString ret;
+  ret.FromString(s);
+  return ret;
 }
 
 CefString AppGetChromiumVersionString() {
-  // TODO
-  return CefString("");
+  std::wostringstream versionStream(L"");
+  versionStream << L"Chrome/" << cef_version_info(2) << L"." << cef_version_info(3)
+                << L"." << cef_version_info(4) << L"." << cef_version_info(5);
+
+  return CefString(versionStream.str());
 }
+

--- a/appshell/version_linux.h
+++ b/appshell/version_linux.h
@@ -1,0 +1,1 @@
+#define APP_VERSION "1.3.0.0"

--- a/tasks/set-release.js
+++ b/tasks/set-release.js
@@ -51,6 +51,7 @@ module.exports = function (grunt) {
             wxsPath                     = "installer/win/Brackets.wxs",
             versionRcPath               = "appshell/version.rc",
             infoPlistPath               = "appshell/mac/Info.plist",
+            linuxVersionFile            = "appshell/version_linux.h",
             release                     = grunt.option("release") || "",
             text,
             newVersion;
@@ -115,5 +116,14 @@ module.exports = function (grunt) {
             "$1" + newVersion.version + "$3"
         );
         grunt.file.write(infoPlistPath, text);
+
+        // 6. Open appshell/version_linux.h and change `APP_VERSION`
+        text = grunt.file.read(linuxVersionFile);
+        text = safeReplace(
+            text,
+            /APP_VERSION "(\d+\.\d+\.\d+\.\d+)"/,
+            'APP_VERSION "' + newVersion.major + "." + newVersion.minor + "." + newVersion.patch + "." + (newVersion.build.length ? newVersion.build : "0") + '"'
+        );
+        grunt.file.write(linuxVersionFile, text);
     });
 };


### PR DESCRIPTION
`AppGetProductVersionString` uses a newly created `version_linux.h` file including only a `APP_VERSION` constant as there seems to be no other way to retrieve version number on Linux.
The functions work, but unfortunately the user agent string (`navigator.userAgent`) doesn't yet contain these strings as there's a Linux-only issue that was fixed in CEF 1650 (https://bitbucket.org/chromiumembedded/cef/issues/1149/cefsettingsproduct_version-has-no-impact)
