### PR TITLE
Command line script and renaming Brackets.sh -> brackets.sh

### DIFF
--- a/appshell/appshell_extensions.js
+++ b/appshell/appshell_extensions.js
@@ -120,7 +120,7 @@ if (!appshell.app) {
     appshell.app.ERR_CL_TOOLS_MKDIRFAILED   = 14;
     
     /**
-     * @constant The required browser is not installed
+     * @constant Symlink creation failed
      */
     appshell.app.ERR_CL_TOOLS_SYMLINKFAILED = 15;
     

--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -1210,7 +1210,7 @@ int32 InstallCommandLineTools()
     int32    errorCode   = NO_ERROR;
 
 
-    std::string destFile   = "/usr/local/bin/Brackets";
+    std::string destFile   = "/usr/local/bin/brackets";
     std::string destFolder = "/usr/local/bin";
 
     std::string rmTool     = "/bin/rm";
@@ -1226,6 +1226,25 @@ int32 InstallCommandLineTools()
     AuthorizationRef authorizationRef = NULL;
     
     try {
+        
+        // Determine the location of the launch script.
+        // We have this file, brackets.sh, present inside resource folder.
+        
+
+        NSString* sourcePath;
+        
+        sourcePath = [[NSBundle mainBundle] pathForResource: @"brackets" ofType: @"sh"];
+        if(!sourcePath) {
+            // If we have not found this in the bundle try the hard path.
+            NSString* bundlePath = [[NSBundle mainBundle] bundlePath];
+            sourcePath = [bundlePath stringByAppendingString:@"/Contents/Resources/brackets.sh"];
+        }
+        
+        if(!sourcePath)
+            return ERR_FILE_NOT_FOUND;
+        
+        std::string sourceFile = [sourcePath UTF8String];
+        
         // AuthorizationCreate and pass NULL as the initial
         // AuthorizationRights set so that the AuthorizationRef gets created
         // successfully.
@@ -1236,21 +1255,6 @@ int32 InstallCommandLineTools()
         
         if(authStatus == errAuthorizationSuccess) {
             
-            // Determine the location of the create the launch script.
-            // We have this file, Brackets.sh, present inside resource folder.
-            
-            NSString* bundlePath = [[NSBundle mainBundle] bundlePath];
-            NSString* sourcePath;
-            NSRange range = [bundlePath rangeOfString: @"/Frameworks/"];
-            
-            if (range.location == NSNotFound) {
-                sourcePath = [[NSBundle mainBundle] pathForResource: @"Brackets" ofType: @"sh"];
-            } else {
-                sourcePath = [bundlePath substringToIndex:range.location];
-                sourcePath = [sourcePath stringByAppendingString:@"/Resources/Brackets.sh"];
-            }
-
-            std::string sourceFile = [sourcePath UTF8String];
 
             std::vector<std::string> args;
 

--- a/appshell/mac/Brackets.sh
+++ b/appshell/mac/Brackets.sh
@@ -1,8 +1,42 @@
 #!/bin/bash
 
-# Give preference to launching the one in /Applications folder
-if [ -x "/Applications/Brackets.app" ]; then
-    open -a /Applications/Brackets.app "$@"
+TARGET_FILE=$0
+BRACKETS_APP_NAME="Brackets.app"
+
+# These are to check for any instances of there are thete
+BASE_APP_NAME="Brackets"
+BASE_APP_EXT=".app"
+
+TARGET_PATH="$(readlink "$TARGET_FILE")"
+TARGET_DIR="$(dirname "$TARGET_PATH")"
+
+FINAL_APP_PATH=TARGET_DIR
+if [ ! -z "$TARGET_PATH" -a ! -z "$TARGET_DIR" ]; then
+    BASE_PATH_NAME="$(basename "$TARGET_DIR")"
+
+    # Now that we have found the location go about
+    # trying to find the enclosing app path.
+    while [[ "$BASE_PATH_NAME" != *.app ]]
+    do
+        TARGET_DIR="$(dirname "$TARGET_DIR")"
+        BASE_PATH_NAME="$(basename "$TARGET_DIR")"
+        if [ -z "$TARGET_DIR" -o "$TARGET_DIR" == "/" ]; then
+            TARGET_DIR="";
+            break;
+        fi
+    done
+    FINAL_APP_PATH=TARGET_DIR
+else
+    FINAL_APP_PATH="";
+fi
+
+# Give preference to launching the script's enclosing app
+if [ -x "$FINAL_APP_PATH" ]; then
+    open -a "$FINAL_APP_PATH" "$@"
+elif [ -x "/Applications/$BRACKETS_APP_NAME" ]; then
+    open -a /Applications/$BRACKETS_APP_NAME "$@"
+elif [ -x "$HOME/Applications/$BRACKETS_APP_NAME" ]; then
+    open -a $HOME/Applications/$BRACKETS_APP_NAME "$@"
 else
     open -a Brackets "$@"
 fi

--- a/appshell/mac/brackets.sh
+++ b/appshell/mac/brackets.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# The actual location of the symlink is passed
+# in $0. We first get the correct target from the
+# symlink and then go about finding the enclosing
+# app. Once a .app is found, we plainly pass the
+# location of the app to open command with a -a
+# as an argument. Note that readlink works differntly
+# on mac.
+
 TARGET_FILE=$0
 BRACKETS_APP_NAME="Brackets.app"
 
@@ -27,12 +35,15 @@ else
 fi
 
 # Give preference to launching the script's enclosing app
+# followed by the one in HOME/Applications. Last one
+# would be checked for global /Applications
+
 if [ -x "$FINAL_APP_PATH" ]; then
     open -a "$FINAL_APP_PATH" "$@"
-elif [ -x "/Applications/$BRACKETS_APP_NAME" ]; then
-    open -a /Applications/$BRACKETS_APP_NAME "$@"
 elif [ -x "$HOME/Applications/$BRACKETS_APP_NAME" ]; then
     open -a $HOME/Applications/$BRACKETS_APP_NAME "$@"
+elif [ -x "/Applications/$BRACKETS_APP_NAME" ]; then
+    open -a /Applications/$BRACKETS_APP_NAME "$@"
 else
     open -a Brackets "$@"
 fi

--- a/appshell/mac/brackets.sh
+++ b/appshell/mac/brackets.sh
@@ -3,14 +3,10 @@
 TARGET_FILE=$0
 BRACKETS_APP_NAME="Brackets.app"
 
-# These are to check for any instances of there are thete
-BASE_APP_NAME="Brackets"
-BASE_APP_EXT=".app"
-
 TARGET_PATH="$(readlink "$TARGET_FILE")"
 TARGET_DIR="$(dirname "$TARGET_PATH")"
 
-FINAL_APP_PATH=TARGET_DIR
+FINAL_APP_PATH="$TARGET_DIR"
 if [ ! -z "$TARGET_PATH" -a ! -z "$TARGET_DIR" ]; then
     BASE_PATH_NAME="$(basename "$TARGET_DIR")"
 
@@ -25,7 +21,7 @@ if [ ! -z "$TARGET_PATH" -a ! -z "$TARGET_DIR" ]; then
             break;
         fi
     done
-    FINAL_APP_PATH=TARGET_DIR
+    FINAL_APP_PATH="$TARGET_DIR"
 else
     FINAL_APP_PATH="";
 fi

--- a/appshell_paths.gypi
+++ b/appshell_paths.gypi
@@ -282,7 +282,7 @@
       'appshell/mac/Japanese.lproj/MainMenu.xib',
       'appshell/mac/Info.plist',
       'appshell/appshell_extensions.js',
-      'appshell/mac/Brackets.sh',
+      'appshell/mac/brackets.sh',
       'appshell/mac/window-close-active.png',
       'appshell/mac/window-close-active@2x.png',
       'appshell/mac/window-close-dirty-active.png',


### PR DESCRIPTION
This change contains the following changes 
* Renames Brackets.sh to brackets.sh 
* Made some changes to script that fixes a unit testing bug
* Update the gyp script to copy brackets.sh instead of Brackets.sh