### PR TITLE
Windows Installer changes for optional PATH and context menu updating along with command line script addition.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -114,7 +114,8 @@ module.exports = function (grunt) {
                             "cef_200_percent.pak",
                             "devtools_resources.pak",
                             "icudtl.dat",
-                            "libcef.dll"
+                            "libcef.dll",
+                            "command/**"
                         ],
                         "dest"      : "installer/win/staging/"
                     }

--- a/appshell.gyp
+++ b/appshell.gyp
@@ -159,6 +159,11 @@
               # Copy locales
               'destination': '<(PRODUCT_DIR)',
               'files': ['Resources/locales/'],
+            },
+            {
+              # Copy windows command line script
+              'destination': '<(PRODUCT_DIR)command',
+              'files': ['scripts/brackets.bat'],
             }
           ],
         }],

--- a/installer/win/Brackets.wxs
+++ b/installer/win/Brackets.wxs
@@ -62,14 +62,6 @@
                                Name="!(loc.ProductName) FileExt" Type="string" />
             <?endforeach?>
             
-            <!-- Add Open With Brackets to explorer's file context menu -->
-            <RegistryValue Root="HKCR" Key="*\shell\!(loc.OpenWithText)\command" Value="[INSTALLDIR]$(var.ExeName).exe &quot;%1&quot;"
-                               Type="string" />
-            
-            <!-- Add Open With Brackets to explorer's folder context menu -->
-            <RegistryValue Root="HKCR" Key="Folder\shell\!(loc.OpenWithText)\command" Value="[INSTALLDIR]$(var.ExeName).exe &quot;%1&quot;"
-                               Type="string" />
-            
             <!-- create ProgId entry -->
             <RegistryValue Root="HKLM" Key="SOFTWARE\Classes\!(loc.ProductName) FileExt\shell\open\command"
                            Value="&quot;[INSTALLDIR]$(var.ExeName).exe&quot; &quot;%1&quot;" Type="string" />
@@ -77,6 +69,22 @@
                            Value="[INSTALLDIR]$(var.ExeName).exe,0" Type="string" />
             <RegistryValue Root="HKLM" Key="SOFTWARE\Classes\!(loc.ProductName) FileExt\shell\open"
                            Name="FriendlyAppName" Value="!(loc.ProductName)" Type="string" />
+
+            <!-- Add an entry to make sure it is runnable via Run Command  -->
+            <RegistryValue Root="HKLM" Key="SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\Brackets.exe" Value="[INSTALLDIR]$(var.ExeName).exe"
+                               Type="string" />
+        </Component>
+
+        <Component Id="AddContextMenu"
+                         Guid="5E95F75D-91C4-44B6-B8A3-83005388B4BF" Directory="INSTALLDIR" KeyPath="yes">
+
+            <!-- Add Open With Brackets to explorer's file context menu -->
+            <RegistryValue Root="HKCR" Key="*\shell\!(loc.OpenWithText)\command" Value="[INSTALLDIR]$(var.ExeName).exe &quot;%1&quot;"
+                               Type="string" />
+
+            <!-- Add Open With Brackets to explorer's folder context menu -->
+            <RegistryValue Root="HKCR" Key="Folder\shell\!(loc.OpenWithText)\command" Value="[INSTALLDIR]$(var.ExeName).exe &quot;%1&quot;"
+                               Type="string" />
         </Component>
         
         <!-- Start Menu Shortcuts-->
@@ -114,7 +122,7 @@
                                  Name="PATH"
                                  Permanent="no"
                                  System="yes"
-                                 Value="[INSTALLDIR]" />
+                                 Value="[INSTALLDIR]command" />
                   </Component>
                 </Directory>
             </Directory>
@@ -131,8 +139,15 @@
             <ComponentRef  Id='StartMenuShortcut' />
 
             <ComponentRef  Id='FileAssociations' />
+        </Feature>
+
+        <Feature Id="UpdatePath" Title="Updating Path Variable" Level="1">
             <ComponentRef  Id="UpdatePath" />
-        </Feature>                  
+        </Feature>
+        
+        <Feature Id="AddContextMenu" Title="Adding Context Menus" Level="1">
+            <ComponentRef  Id="AddContextMenu" />
+        </Feature>
 
         <SetProperty Id="ARPINSTALLLOCATION" Value="[INSTALLDIR]" After="CostFinalize" />    
     </Product>

--- a/installer/win/Brackets.wxs
+++ b/installer/win/Brackets.wxs
@@ -79,11 +79,11 @@
                          Guid="5E95F75D-91C4-44B6-B8A3-83005388B4BF" Directory="INSTALLDIR" KeyPath="yes">
 
             <!-- Add Open With Brackets to explorer's file context menu -->
-            <RegistryValue Root="HKCR" Key="*\shell\!(loc.OpenWithText)\command" Value="[INSTALLDIR]$(var.ExeName).exe &quot;%1&quot;"
+            <RegistryValue Root="HKCR" Key="*\shell\!(loc.ExplorerFileOpenContextMenu)\command" Value="[INSTALLDIR]$(var.ExeName).exe &quot;%1&quot;"
                                Type="string" />
 
             <!-- Add Open With Brackets to explorer's folder context menu -->
-            <RegistryValue Root="HKCR" Key="Folder\shell\!(loc.OpenWithText)\command" Value="[INSTALLDIR]$(var.ExeName).exe &quot;%1&quot;"
+            <RegistryValue Root="HKCR" Key="Folder\shell\!(loc.ExplorerFolderOpenContextMenu)\command" Value="[INSTALLDIR]$(var.ExeName).exe &quot;%1&quot;"
                                Type="string" />
         </Component>
         

--- a/installer/win/Brackets_en-us.wxl
+++ b/installer/win/Brackets_en-us.wxl
@@ -57,5 +57,5 @@
     <String Id="ExplorerFileOpenContextMenu" Overridable="yes">Open with !(loc.ShortProductName)</String>
     <String Id="ExplorerFolderOpenContextMenu" Overridable="yes">Open as !(loc.ShortProductName) project</String>
     <String Id="AddBracketsToPath" Overridable="yes">Add &quot;!(loc.smallProductName)&quot; launcher to PATH for command line use</String>
-    <String Id="AddContextMenu" Overridable="yes">Add &quot;Open With !(loc.ShortProductName)&quot; to Explorer context menus for all files and folders</String>
+    <String Id="AddContextMenu" Overridable="yes">Add &quot;Open with !(loc.ShortProductName)&quot; to Explorer context menus for all files and folders</String>
 </WixLocalization>

--- a/installer/win/Brackets_en-us.wxl
+++ b/installer/win/Brackets_en-us.wxl
@@ -55,4 +55,6 @@
     <String Id="VerifyReadyDlgInstallText" Overridable="yes">Click Install to begin, or Cancel to exit.</String>
     <String Id="VerifyReadyDlgRemoveText" Overridable="yes">Click Remove to uninstall !(loc.ShortProductName), or Cancel to exit.</String>
     <String Id="OpenWithText" Overridable="yes">Open With !(loc.ShortProductName)</String>
+    <String Id="AddBracketsToPath" Overridable="yes">Update PATH environment variable with !(loc.ShortProductName) install location (in order to launch !(loc.ShortProductName) from command line)</String>
+    <String Id="AddContextMenu" Overridable="yes">Add &quot;Open With !(loc.ShortProductName) &quot; menu to file and folder context menus</String>
 </WixLocalization>

--- a/installer/win/Brackets_en-us.wxl
+++ b/installer/win/Brackets_en-us.wxl
@@ -19,7 +19,7 @@
     <!-- See also: product name definitions in brackets-win-install-build.xml -->
     <String Id="ProductName">Brackets</String>
     <String Id="ShortProductName">Brackets</String>
-  
+    <String Id="smallProductName">brackets</String>
     <String Id="LanguageID" Overridable="yes">1033</String>
         
     <String Id="StandardDlg_Title" Overridable="yes">[ProductName] Installer</String>
@@ -54,7 +54,8 @@
     <String Id="ExitDialogTitle" Overridable="yes">{\WixUI_Font_BannerTitle}Completed the [ProductName] Setup Wizard</String>
     <String Id="VerifyReadyDlgInstallText" Overridable="yes">Click Install to begin, or Cancel to exit.</String>
     <String Id="VerifyReadyDlgRemoveText" Overridable="yes">Click Remove to uninstall !(loc.ShortProductName), or Cancel to exit.</String>
-    <String Id="OpenWithText" Overridable="yes">Open With !(loc.ShortProductName)</String>
-    <String Id="AddBracketsToPath" Overridable="yes">Update PATH environment variable with !(loc.ShortProductName) install location (in order to launch !(loc.ShortProductName) from command line)</String>
-    <String Id="AddContextMenu" Overridable="yes">Add &quot;Open With !(loc.ShortProductName) &quot; menu to file and folder context menus</String>
+    <String Id="ExplorerFileOpenContextMenu" Overridable="yes">Open with !(loc.ShortProductName)</String>
+    <String Id="ExplorerFolderOpenContextMenu" Overridable="yes">Open as !(loc.ShortProductName) project</String>
+    <String Id="AddBracketsToPath" Overridable="yes">Add &quot;!(loc.smallProductName)&quot; launcher to PATH for command line use</String>
+    <String Id="AddContextMenu" Overridable="yes">Add &quot;Open With !(loc.ShortProductName)&quot; to Explorer context menus for all files and folders</String>
 </WixLocalization>

--- a/installer/win/Brackets_fr-fr.wxl
+++ b/installer/win/Brackets_fr-fr.wxl
@@ -54,6 +54,8 @@
     <String Id="VerifyReadyDlgInstallText" Overridable="yes">Cliquez sur Installer pour lancer la procédure ou sur Annuler pour quitter.</String>
     <String Id="VerifyReadyDlgRemoveText" Overridable="yes">Cliquez sur Supprimer pour désinstaller !(loc.ShortProductName) ou sur Annuler pour quitter.</String>
     <String Id="OpenWithText" Overridable="yes">Open With !(loc.ShortProductName)</String>
+    <String Id="AddBracketsToPath" Overridable="yes">Update PATH environment variable with !(loc.ShortProductName) install location (in order to launch !(loc.ShortProductName) from command line)</String>
+    <String Id="AddContextMenu" Overridable="yes">Add &quot;Open With !(loc.ShortProductName) &quot; menu to file and folder context menus</String>
       
     <!-- these strings aren't necessarily used but they were modified by the adobe loc team after they reviewed the wix source fr-fr wxl file.
     Adding them here if it works to call multiple loc files with the light command that are part of the same culture -->

--- a/installer/win/Brackets_fr-fr.wxl
+++ b/installer/win/Brackets_fr-fr.wxl
@@ -56,7 +56,7 @@
     <String Id="ExplorerFileOpenContextMenu" Overridable="yes">Open with !(loc.ShortProductName)</String>
     <String Id="ExplorerFolderOpenContextMenu" Overridable="yes">Open as !(loc.ShortProductName) project</String>
     <String Id="AddBracketsToPath" Overridable="yes">Add &quot;!(loc.smallProductName)&quot; launcher to PATH for command line use</String>
-    <String Id="AddContextMenu" Overridable="yes">Add &quot;Open With !(loc.ShortProductName)&quot; to Explorer context menus for all files and folders</String>
+    <String Id="AddContextMenu" Overridable="yes">Add &quot;Open with !(loc.ShortProductName)&quot; to Explorer context menus for all files and folders</String>
       
     <!-- these strings aren't necessarily used but they were modified by the adobe loc team after they reviewed the wix source fr-fr wxl file.
     Adding them here if it works to call multiple loc files with the light command that are part of the same culture -->

--- a/installer/win/Brackets_fr-fr.wxl
+++ b/installer/win/Brackets_fr-fr.wxl
@@ -18,7 +18,7 @@
     
     <String Id="ProductName">Brackets</String>
     <String Id="ShortProductName">Brackets</String>
-  
+    <String Id="smallProductName">brackets</String>
     <String Id="LanguageID" Overridable="yes">1036</String>
         
     <String Id="StandardDlg_Title" Overridable="yes">Programme d’installation de [ProductName]</String>
@@ -53,9 +53,10 @@
     <String Id="ExitDialogTitle" Overridable="yes">{\WixUI_Font_BannerTitle}Procédure de l’assistant d’installation de [ProductName] terminée</String>
     <String Id="VerifyReadyDlgInstallText" Overridable="yes">Cliquez sur Installer pour lancer la procédure ou sur Annuler pour quitter.</String>
     <String Id="VerifyReadyDlgRemoveText" Overridable="yes">Cliquez sur Supprimer pour désinstaller !(loc.ShortProductName) ou sur Annuler pour quitter.</String>
-    <String Id="OpenWithText" Overridable="yes">Open With !(loc.ShortProductName)</String>
-    <String Id="AddBracketsToPath" Overridable="yes">Update PATH environment variable with !(loc.ShortProductName) install location (in order to launch !(loc.ShortProductName) from command line)</String>
-    <String Id="AddContextMenu" Overridable="yes">Add &quot;Open With !(loc.ShortProductName) &quot; menu to file and folder context menus</String>
+    <String Id="ExplorerFileOpenContextMenu" Overridable="yes">Open with !(loc.ShortProductName)</String>
+    <String Id="ExplorerFolderOpenContextMenu" Overridable="yes">Open as !(loc.ShortProductName) project</String>
+    <String Id="AddBracketsToPath" Overridable="yes">Add &quot;!(loc.smallProductName)&quot; launcher to PATH for command line use</String>
+    <String Id="AddContextMenu" Overridable="yes">Add &quot;Open With !(loc.ShortProductName)&quot; to Explorer context menus for all files and folders</String>
       
     <!-- these strings aren't necessarily used but they were modified by the adobe loc team after they reviewed the wix source fr-fr wxl file.
     Adding them here if it works to call multiple loc files with the light command that are part of the same culture -->

--- a/installer/win/InstallDirDlg.wxs
+++ b/installer/win/InstallDirDlg.wxs
@@ -16,8 +16,16 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Fragment>
         <UI>
+
+            <Property Id="UPDATEPATH" Value="1"/>
+            <Property Id="ADDCONTEXTMENU" Value="1" />
+
             <Dialog Id="MyInstallDirDlg" Width="370" Height="270" Title="!(loc.StandardDlg_Title)">
-                <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="!(loc.WixUINext)" />
+                <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="!(loc.WixUINext)">
+                    <Publish Event="AddLocal" Value="ALL">1</Publish>
+                    <Publish Event="Remove" Value="UpdatePath">NOT UPDATEPATH</Publish>
+                    <Publish Event="Remove" Value="AddContextMenu">NOT ADDCONTEXTMENU</Publish>
+                </Control>
                 <!-- <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)" /> -->
                 <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
                     <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
@@ -32,6 +40,8 @@
                 <!--<Control Id="FolderLabel" Type="Text" X="20" Y="60" Width="290" Height="30" NoPrefix="yes" Text="!(loc.InstallDirDlgFolderLabel)" />-->
                 <Control Id="Folder" Type="PathEdit" X="20" Y="100" Width="320" Height="18" Property="WIXUI_INSTALLDIR" Indirect="yes" />
                 <Control Id="ChangeFolder" Type="PushButton" X="20" Y="120" Width="56" Height="17" Text="!(loc.InstallDirDlgChange)" />
+                <Control Id="UpdatePath_ChkBox" Type="CheckBox" X="20" Y="160" Width="290" Height="17" Property="UPDATEPATH" CheckBoxValue="1" Text="!(loc.AddBracketsToPath)" />
+                <Control Id="AddContextMenu_ChkBox" Type="CheckBox" X="20" Y="190" Width="290" Height="17" Property="ADDCONTEXTMENU" CheckBoxValue="1" Text="!(loc.AddContextMenu)" /> 
             </Dialog>
             <InstallUISequence>
                 <Show Dialog="MyInstallDirDlg" Before="MyProgressDlg" Overridable="yes">NOT Installed</Show>

--- a/scripts/brackets.bat
+++ b/scripts/brackets.bat
@@ -1,0 +1,2 @@
+@echo off
+start Brackets.exe %*


### PR DESCRIPTION
This change involves the following

1) Made the update path and context menu addition to file and folder context menus optional.
2) The PATH varible will now be [INSTALLDIR]/command.
3) Changed project setup scripts to create commands/brackets.bat by copying it from scripts/brackets.bat
4) Changed the Gruntfile to copy the new folder command to Brackets staging area.