### PR TITLE
fixed can't remove menu divider on windows

### DIFF
--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -1732,7 +1732,7 @@ int32 AddMenuItem(CefRefPtr<CefBrowser> browser, ExtensionString parentCommand, 
 
         if (isSeparator) 
         {
-            res = AppendMenu(submenu, MF_SEPARATOR, NULL, NULL);
+            res = AppendMenu(submenu, MF_SEPARATOR, tag, NULL);
         } else {
             res = AppendMenu(submenu, MF_STRING, tag, title.c_str());
         }


### PR DESCRIPTION
On windows in AddMenuItem function, if item is a Separator enter 
if (isSeparator) 
{
    res = AppendMenu(submenu, MF_SEPARATOR, NULL, NULL);
}  else {
     res = AppendMenu(submenu, MF_STRING, tag, title.c_str());
}

The 3rd param is the item's tag, but it passed a NULL.

In RemoveMenuItem, DeleteMenu(mainMenu, tag, MF_BYCOMMAND) need a tag to find which item to remove.

So i change the 3rd param to tag :

if (isSeparator) 
{
    res = AppendMenu(submenu, MF_SEPARATOR, tag, NULL);
}  else {
     res = AppendMenu(submenu, MF_STRING, tag, title.c_str());
}

And i test it works well now on windows.
