### PR TITLE
Fixes for folder context menu appearing for folders like Recycle bin and brackets launcher script from shell emulators.

### DIFF
--- a/appshell.gyp
+++ b/appshell.gyp
@@ -163,7 +163,7 @@
             {
               # Copy windows command line script
               'destination': '<(PRODUCT_DIR)command',
-              'files': ['scripts/brackets.bat'],
+              'files': ['scripts/brackets.bat', 'scripts/brackets'],
             }
           ],
         }],

--- a/installer/win/Brackets.wxs
+++ b/installer/win/Brackets.wxs
@@ -79,12 +79,25 @@
                          Guid="5E95F75D-91C4-44B6-B8A3-83005388B4BF" Directory="INSTALLDIR" KeyPath="yes">
 
             <!-- Add Open With Brackets to explorer's file context menu -->
-            <RegistryValue Root="HKCR" Key="*\shell\!(loc.ExplorerFileOpenContextMenu)\command" Value="[INSTALLDIR]$(var.ExeName).exe &quot;%1&quot;"
+            <RegistryValue Root="HKCR" Key="*\shell\!(loc.ProductName)" Value="!(loc.ExplorerFileOpenContextMenu)"
+                               Type="string" />
+
+            <RegistryValue Root="HKCR" Key="*\shell\!(loc.ProductName)" Name="Icon" Value="[INSTALLDIR]$(var.ExeName).exe"
+                               Type="string" />
+
+            <RegistryValue Root="HKCR" Key="*\shell\!(loc.ProductName)\command" Value="[INSTALLDIR]$(var.ExeName).exe &quot;%1&quot;"
                                Type="string" />
 
             <!-- Add Open With Brackets to explorer's folder context menu -->
-            <RegistryValue Root="HKCR" Key="Folder\shell\!(loc.ExplorerFolderOpenContextMenu)\command" Value="[INSTALLDIR]$(var.ExeName).exe &quot;%1&quot;"
+            <RegistryValue Root="HKCR" Key="directory\shell\!(loc.ProductName)" Value="!(loc.ExplorerFolderOpenContextMenu)"
                                Type="string" />
+
+            <RegistryValue Root="HKCR" Key="directory\shell\!(loc.ProductName)" Name="Icon" Value="[INSTALLDIR]$(var.ExeName).exe"
+                               Type="string" />
+
+            <RegistryValue Root="HKCR" Key="directory\shell\!(loc.ProductName)\command" Value="[INSTALLDIR]$(var.ExeName).exe &quot;%1&quot;"
+                               Type="string" />
+
         </Component>
         
         <!-- Start Menu Shortcuts-->

--- a/installer/win/Brackets.wxs
+++ b/installer/win/Brackets.wxs
@@ -89,7 +89,7 @@
                                Type="string" />
 
             <!-- Add Open With Brackets to explorer's folder context menu -->
-            <RegistryValue Root="HKCR" Key="directory\shell\!(loc.ProductName)" Value="!(loc.ExplorerFolderOpenContextMenu)"
+            <RegistryValue Root="HKCR" Key="directory\shell\!(loc.ProductName)" Value="!(loc.ExplorerDirectoryOpenContextMenu)"
                                Type="string" />
 
             <RegistryValue Root="HKCR" Key="directory\shell\!(loc.ProductName)" Name="Icon" Value="[INSTALLDIR]$(var.ExeName).exe"

--- a/installer/win/Brackets_en-us.wxl
+++ b/installer/win/Brackets_en-us.wxl
@@ -55,7 +55,7 @@
     <String Id="VerifyReadyDlgInstallText" Overridable="yes">Click Install to begin, or Cancel to exit.</String>
     <String Id="VerifyReadyDlgRemoveText" Overridable="yes">Click Remove to uninstall !(loc.ShortProductName), or Cancel to exit.</String>
     <String Id="ExplorerFileOpenContextMenu" Overridable="yes">Open with !(loc.ShortProductName)</String>
-    <String Id="ExplorerFolderOpenContextMenu" Overridable="yes">Open as !(loc.ShortProductName) project</String>
+    <String Id="ExplorerDirectoryOpenContextMenu" Overridable="yes">Open as !(loc.ShortProductName) project</String>
     <String Id="AddBracketsToPath" Overridable="yes">Add &quot;!(loc.SmallProductName)&quot; launcher to PATH for command line use</String>
     <String Id="AddContextMenu" Overridable="yes">Add &quot;Open with !(loc.ShortProductName)&quot; to Explorer context menus for all files and folders</String>
 </WixLocalization>

--- a/installer/win/Brackets_fr-fr.wxl
+++ b/installer/win/Brackets_fr-fr.wxl
@@ -54,7 +54,7 @@
     <String Id="VerifyReadyDlgInstallText" Overridable="yes">Cliquez sur Installer pour lancer la procédure ou sur Annuler pour quitter.</String>
     <String Id="VerifyReadyDlgRemoveText" Overridable="yes">Cliquez sur Supprimer pour désinstaller !(loc.ShortProductName) ou sur Annuler pour quitter.</String>
     <String Id="ExplorerFileOpenContextMenu" Overridable="yes">Ouvrir avec !(loc.ShortProductName)</String>
-    <String Id="ExplorerFolderOpenContextMenu" Overridable="yes">Ouvrir en tant que projet !(loc.ShortProductName)</String>
+    <String Id="ExplorerDirectoryOpenContextMenu" Overridable="yes">Ouvrir en tant que projet !(loc.ShortProductName)</String>
     <String Id="AddBracketsToPath" Overridable="yes">Ajouter le lanceur &quot;!(loc.SmallProductName)&quot; sous PATH pour l’utilisation de la ligne de commande</String>
     <String Id="AddContextMenu" Overridable="yes">Ajouter l’option &quot;Ouvrir avec !(loc.ShortProductName)&quot; aux menus contextuels de l’Explorateur pour l’ensemble des fichiers et dossiers</String>
       

--- a/scripts/brackets
+++ b/scripts/brackets
@@ -1,0 +1,33 @@
+#!/bin/sh
+(set -o igncr) 2>/dev/null && set -o igncr; # cygwin encoding fix
+
+# Run through the current and parent directories for Brackets.exe
+# and execute when found. $0 is the path to this script.
+
+TARGET_PATH="$(dirname "$0")"
+
+case `uname` in
+    *CYGWIN*) OS_NAME="CYGWIN";;
+esac
+
+if [ "$OS_NAME" == "CYGWIN" ]; then
+    TARGET_PATH=`cygpath -w "$TARGET_PATH"`
+fi
+
+while [ ! -z "$TARGET_PATH"  -a "$TARGET_PATH" != "/" ]
+do
+    if [ -x "$TARGET_PATH/Brackets.exe" ]; then
+        break;
+    fi
+
+    TARGET_PATH="$(dirname "$TARGET_PATH")"
+    if [ OS_NAME == 'CYGWIN' ]; then
+        TARGET_PATH=`cygpath -w "$TARGET_PATH"`
+    fi
+done
+
+if [ ! -z "$TARGET_PATH" -a -x "$TARGET_PATH/Brackets.exe" ]; then
+    "$TARGET_PATH/Brackets.exe" "$@"
+else
+    echo "Unable to launch Brackets as Brackets.exe could not be located. Try re-installing Brackets."
+fi


### PR DESCRIPTION
1) Moved the registry entries in the installer to HKCR\directory from HKCR\folder as this was leading to "Open as Brackets project" at all the locations including "Recycle Bin"
2) Added a new script to command folder which takes care of launching Brackets from emulators like MINGW32 and CYGWIN.