### PR TITLE
Changed launch script for bash shell to launch Brackets in a non blocking way

### DIFF
--- a/scripts/brackets
+++ b/scripts/brackets
@@ -8,10 +8,10 @@ TARGET_PATH="$(dirname "$0")"
 
 case `uname` in
     *CYGWIN*) OS_NAME="CYGWIN";;
-    *MINGW32_NT*) OS_NAME="MINGWIN";;
+    *MINGW32_NT*) OS_NAME="MinGW";;
 esac
 
-if [ "$OS_NAME" == "MINGWIN" ]; then
+if [ "$OS_NAME" == "MinGW" ]; then
     # Suprisingly MING32 platform recognizes
     # windows "start" command. Use this against
     # launching .exe as the later is blocking.

--- a/scripts/brackets
+++ b/scripts/brackets
@@ -8,26 +8,37 @@ TARGET_PATH="$(dirname "$0")"
 
 case `uname` in
     *CYGWIN*) OS_NAME="CYGWIN";;
+    *MINGW32_NT*) OS_NAME="MINGWIN";;
 esac
 
-if [ "$OS_NAME" == "CYGWIN" ]; then
-    TARGET_PATH=`cygpath -w "$TARGET_PATH"`
-fi
-
-while [ ! -z "$TARGET_PATH"  -a "$TARGET_PATH" != "/" ]
-do
-    if [ -x "$TARGET_PATH/Brackets.exe" ]; then
-        break;
-    fi
-
-    TARGET_PATH="$(dirname "$TARGET_PATH")"
-    if [ OS_NAME == 'CYGWIN' ]; then
+if [ "$OS_NAME" == "MINGWIN" ]; then
+    # Suprisingly MING32 platform recognizes
+    # windows "start" command. Use this against
+    # launching .exe as the later is blocking.
+    start "Brackets.exe" "$@"
+else
+    if [ "$OS_NAME" == "CYGWIN" ]; then
         TARGET_PATH=`cygpath -w "$TARGET_PATH"`
     fi
-done
 
-if [ ! -z "$TARGET_PATH" -a -x "$TARGET_PATH/Brackets.exe" ]; then
-    "$TARGET_PATH/Brackets.exe" "$@"
-else
-    echo "Unable to launch Brackets as Brackets.exe could not be located. Try re-installing Brackets."
+    while [ ! -z "$TARGET_PATH" ] && [ "$TARGET_PATH" != "/" ] && [ "$TARGET_PATH" != "." ]
+    do
+        if [ -x "$TARGET_PATH/Brackets.exe" ]; then
+            break;
+        fi
+
+        TARGET_PATH="$(dirname "$TARGET_PATH")"
+        if [ OS_NAME == 'CYGWIN' ]; then
+            TARGET_PATH=`cygpath -w "$TARGET_PATH"`
+        fi
+    done
+
+    # Unfortunately windows "start" command is not recognized natively
+    # and hence have to launch exe from command line prompt in a blocking
+    # way.
+    if [ ! -z "$TARGET_PATH" ] && [ -x "$TARGET_PATH/Brackets.exe" ]; then
+        "$TARGET_PATH/Brackets.exe" "$@"
+    else
+        echo "Unable to launch Brackets as Brackets.exe could not be located. Try re-installing Brackets."
+    fi
 fi


### PR DESCRIPTION
`MING32/git bash` surprisingly understands `start` command. So changed the script to launch Brackets in non- blocking mode. However this does not work well with `CYGWIN`. So retained the earlier way of launching Brackets.exe in blocking mode in `CYGWIN`.