### PR TITLE
Fix compilation on Linux InstallCommandLineTools not in scope

### DIFF
--- a/appshell/appshell_extensions_platform.h
+++ b/appshell/appshell_extensions_platform.h
@@ -73,8 +73,8 @@ inline void* getMenuParent(CefRefPtr<CefBrowser>browser) {
     return gtk_widget_get_ancestor(
         GTK_WIDGET(browser->GetHost()->GetWindowHandle()),
         GTK_TYPE_VBOX);
-inline int32 InstallCommandLineTools() { return ERR_CL_TOOLS_NOTSUPPORTED; }
 }
+inline int32 InstallCommandLineTools() { return ERR_CL_TOOLS_NOTSUPPORTED; }
 #endif
 
 


### PR DESCRIPTION
Small fix to compile in Linux. 
InstallCommandLineTools wasdefined inside getMenuParent