### PR TITLE
Issue #8191 : New instance with shift+click

### DIFF
--- a/appshell/cefclient_win.cpp
+++ b/appshell/cefclient_win.cpp
@@ -182,7 +182,7 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
   if (exit_code >= 0)
     return exit_code;
 
-  bool isShiftKeyDown = (GetAsyncKeyState(VK_SHIFT) & 0x8000) ? true: false;
+  bool isRightShiftKeyDown = (GetAsyncKeyState(VK_RSHIFT) & 0x8000) ? true: false;
 
   // Retrieve the current working directory.
   if (_getcwd(szWorkingDir, MAX_UNC_PATH) == NULL)
@@ -246,8 +246,8 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
 	  wcscpy(szInitialUrl, cmdLine->GetSwitchValue(cefclient::kStartupPath).c_str());
   }
   else {
-	// If the shift key is not pressed, look for the index.html file 
-	if (!isShiftKeyDown) {
+	// If the right shift key is not pressed, look for the index.html file 
+	if (!isRightShiftKeyDown) {
 	// Get the full pathname for the app. We look for the index.html
 	// file relative to this location.
 	wchar_t appPath[MAX_UNC_PATH];


### PR DESCRIPTION
Changed key for on startup being able to specify `index.html` from `shift` to `Right shift`. This makes it possible to start a new instance with `left shift+click` on taskbar with default index.html while still being able to start brackets with `right shift` to specify `index.html`. Suggestion for using `Alt` does not work since holding Alt will open 'Properties' window (on win 8.1).

P.S first contribution on github.. Sorry if im not following protocol here... :)