### PR TITLE
[MAC] Fix for not being able to minimize Brackets full screen window on El Capitan.

### DIFF
--- a/appshell/cefclient_mac.mm
+++ b/appshell/cefclient_mac.mm
@@ -23,6 +23,8 @@
 #include "native_menu_model.h"
 #include "appshell_node_process.h"
 
+#include "AppKit/NSApplication.h"
+
 #include "TrafficLightsView.h"
 #include "TrafficLightsViewController.h"
 #include "client_colors_mac.h"
@@ -249,17 +251,22 @@ extern NSMutableArray* pendingOpenFiles;
 #endif
 }
 
--(BOOL)isRunningOnYosemite {
-    NSDictionary* dict = [NSDictionary dictionaryWithContentsOfFile:@"/System/Library/CoreServices/SystemVersion.plist"];
-    NSString* version =  [dict objectForKey:@"ProductVersion"];
-    return [version hasPrefix:@"10.10"];
+-(BOOL)isRunningOnYosemiteOrLater {
+    // This seems to be a more reliable way of checking
+    // the MACOS version.
+    // https://developer.apple.com/library/mac/documentation/DeveloperTools/Conceptual/cross_development/Using/using.html
+
+    if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_0)
+        return true;
+    else
+        return false;
 }
 
 - (BOOL)isFullScreenSupported {
     // Return False on Yosemite so we
     //  don't draw our own full screen button
     //  and handle full screen mode
-    if (![self isRunningOnYosemite]) {
+    if (![self isRunningOnYosemiteOrLater]) {
         SInt32 version;
         Gestalt(gestaltSystemVersion, &version);
         return (version >= 0x1070);
@@ -268,7 +275,7 @@ extern NSMutableArray* pendingOpenFiles;
 }
 
 -(BOOL)needsFullScreenActivateHack {
-    if (![self isRunningOnYosemite]) {
+    if (![self isRunningOnYosemiteOrLater]) {
         SInt32 version;
         Gestalt(gestaltSystemVersion, &version);
         return (version >= 0x1090);
@@ -277,7 +284,7 @@ extern NSMutableArray* pendingOpenFiles;
 }
 
 -(BOOL)useSystemTrafficLights {
-    return [self isRunningOnYosemite];
+    return [self isRunningOnYosemiteOrLater];
 }
 
 -(void)windowDidResize:(NSNotification *)notification

--- a/appshell/cefclient_mac.mm
+++ b/appshell/cefclient_mac.mm
@@ -263,7 +263,7 @@ extern NSMutableArray* pendingOpenFiles;
     // at the following link.
     // https://developer.apple.com/library/mac/documentation/DeveloperTools/Conceptual/cross_development/Using/using.html
 
-    if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_10)
+    if (NSAppKitVersionNumber >= NSAppKitVersionNumber10_10)
         return true;
     else
         return false;

--- a/appshell/cefclient_mac.mm
+++ b/appshell/cefclient_mac.mm
@@ -34,6 +34,12 @@
 
 #import "CustomTitlebarView.h"
 
+// If app is built with 10.9 or lower
+// this constant is not defined.
+#ifndef NSAppKitVersionNumber10_10
+    #define NSAppKitVersionNumber10_10 1343
+#endif
+
 // Application startup time
 CFTimeInterval g_appStartupTime;
 
@@ -253,10 +259,11 @@ extern NSMutableArray* pendingOpenFiles;
 
 -(BOOL)isRunningOnYosemiteOrLater {
     // This seems to be a more reliable way of checking
-    // the MACOS version.
+    // the MACOS version. Documentation about this available
+    // at the following link.
     // https://developer.apple.com/library/mac/documentation/DeveloperTools/Conceptual/cross_development/Using/using.html
 
-    if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_0)
+    if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_10)
         return true;
     else
         return false;


### PR DESCRIPTION
Fixes the issue with maverick OS style minimize/maximize/close buttons appearing on El Capitan and also fixes 'unable to minimize from a full screen window on MAC OS El Capitan'.

Add a better way of checking for Yosemite. Documentation available at the following location.

https://developer.apple.com/library/mac/documentation/DeveloperTools/Conceptual/cross_development/Using/using.html