### PR TITLE
Add --disable-default-apps-flag for live preview

### DIFF
--- a/appshell/appshell_extensions_gtk.cpp
+++ b/appshell/appshell_extensions_gtk.cpp
@@ -63,7 +63,7 @@ int GErrorToErrorCode(GError *gerror) {
 
 int32 OpenLiveBrowser(ExtensionString argURL, bool enableRemoteDebugging)
 {
-    const char *remoteDebuggingFormat = "--no-first-run --no-default-browser-check --allow-file-access-from-files --temp-profile --user-data-dir=%s --remote-debugging-port=9222";
+    const char *remoteDebuggingFormat = "--no-first-run --no-default-browser-check --disable-default-apps --allow-file-access-from-files --temp-profile --user-data-dir=%s --remote-debugging-port=9222";
     gchar *remoteDebugging;
     gchar *cmdline;
     int error = ERR_BROWSER_NOT_INSTALLED;

--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -257,6 +257,7 @@ int32 OpenLiveBrowser(ExtensionString argURL, bool enableRemoteDebugging)
         NSArray *parameters = [NSArray arrayWithObjects:
                       @"--no-first-run",
                       @"--no-default-browser-check",
+                      @"--disable-default-apps",
                       debugPortCommandlineArguments,
                       debugProfilePath,
                       urlString,

--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -341,7 +341,7 @@ int32 OpenLiveBrowser(ExtensionString argURL, bool enableRemoteDebugging)
         profilePath += L"\\live-dev-profile";
         args += L" --user-data-dir=\"";
         args += profilePath;
-        args += L"\" --no-first-run --no-default-browser-check --allow-file-access-from-files --remote-debugging-port=9222 ";
+        args += L"\" --no-first-run --no-default-browser-check --disable-default-apps --allow-file-access-from-files --remote-debugging-port=9222 ";
     } else {
         args += L" ";
     }


### PR DESCRIPTION
Fixes adobe/brackets#11617.

Currently when Brackets launches live preview (for the first time), it uses a new profile. Chrome then proceeds to install the default Chrome apps (Youtube, Gmail, Google Search, Web Store, Google Docs...) for the said user. This can create situations like described in adobe/brackets#11617.

This PR adds `--disable-default-apps`-flag for remote debugging arguments, which disables that said behaviour. (Plus it could/should make the first live preview experience a tad bit faster :fire:)