### PR TITLE
Revert "Fix for #11112: Command line: "brackets" without arguments al…

### DIFF
--- a/appshell/cefclient_win.cpp
+++ b/appshell/cefclient_win.cpp
@@ -193,35 +193,33 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
 
   // Determine if we should use an already running instance of Brackets.
   HANDLE hMutex = ::OpenMutex(MUTEX_ALL_ACCESS, FALSE, FIRST_INSTANCE_MUTEX_NAME);
-  if (hMutex != NULL) {
-    // for subsequent instances, re-use an already running instance if we're being called to
-    //   open an existing file on the command-line (eg. Open With.. from Windows Explorer)
-    HWND hFirstInstanceWnd = cef_main_window::FindFirstTopLevelInstance();
-    if (hFirstInstanceWnd != NULL) {
-      ::SetForegroundWindow(hFirstInstanceWnd);
-      if (::IsIconic(hFirstInstanceWnd))
-        ::ShowWindow(hFirstInstanceWnd, SW_RESTORE);
-      // Check for arguments. If any pass it to the existing running instance.
-      if( AppGetCommandLine()->HasArguments() && (lpCmdLine != NULL) ){
-        // message the other Brackets instance to actually open the given filename
-        std::wstring filename = lpCmdLine;
-        std::wstring wstrFilename;
-        // We check if this is a valid file path. If not just ignore this parameter.
-        if (GetFullPath(filename, wstrFilename)) {
-          ConvertToUnixPath(wstrFilename);
-          // note: WM_COPYDATA will manage passing the string across process space
-          COPYDATASTRUCT data;
-          data.dwData = ID_WM_COPYDATA_SENDOPENFILECOMMAND;
-          data.cbData = (wstrFilename.length() + 1) * sizeof(WCHAR);
-          data.lpData = (LPVOID)wstrFilename.c_str();
-          ::SendMessage(hFirstInstanceWnd, WM_COPYDATA, (WPARAM)(HWND)hFirstInstanceWnd, (LPARAM)(LPVOID)&data);
-        }
+  if ((hMutex != NULL) && AppGetCommandLine()->HasArguments() && (lpCmdLine != NULL)) {
+   // for subsequent instances, re-use an already running instance if we're being called to
+   //   open an existing file on the command-line (eg. Open With.. from Windows Explorer)
+   HWND hFirstInstanceWnd = cef_main_window::FindFirstTopLevelInstance();
+   if (hFirstInstanceWnd != NULL) {
+     ::SetForegroundWindow(hFirstInstanceWnd);
+    if (::IsIconic(hFirstInstanceWnd))
+      ::ShowWindow(hFirstInstanceWnd, SW_RESTORE);
+
+      // message the other Brackets instance to actually open the given filename
+      std::wstring filename = lpCmdLine;
+      std::wstring wstrFilename;
+      // We check if this is a valid file path. If not just ignore this parameter.
+      if (GetFullPath(filename, wstrFilename)) {
+        ConvertToUnixPath(wstrFilename);
+        // note: WM_COPYDATA will manage passing the string across process space
+        COPYDATASTRUCT data;
+        data.dwData = ID_WM_COPYDATA_SENDOPENFILECOMMAND;
+        data.cbData = (wstrFilename.length() + 1) * sizeof(WCHAR);
+        data.lpData = (LPVOID)wstrFilename.c_str();
+        ::SendMessage(hFirstInstanceWnd, WM_COPYDATA, (WPARAM)(HWND)hFirstInstanceWnd, (LPARAM)(LPVOID)&data);
+        // exit this instance
+        return 0;
       }
-      // exit this instance
-      return 0;
     }
     // otherwise, fall thru and launch a new instance
- }
+  }
 
   if (hMutex == NULL) {
 	  // first instance of this app, so create the mutex and continue execution of this instance.


### PR DESCRIPTION
Reverts adobe/brackets-shell#524. This fixes https://github.com/adobe/brackets/issues/11672 and alike, which crept in because of this change.