### PR TITLE
Full screen issue

### DIFF
--- a/appshell/mac/English.lproj/MainMenu.xib
+++ b/appshell/mac/English.lproj/MainMenu.xib
@@ -76,6 +76,12 @@
                                     <action selector="performZoom:" target="-1" id="240"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Enter Full Screen" keyEquivalent="f" id="241">
+                                <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                <connections>
+                                    <action selector="toggleFullScreen:" target="-1" id="242"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="92">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>

--- a/appshell/mac/French.lproj/MainMenu.xib
+++ b/appshell/mac/French.lproj/MainMenu.xib
@@ -76,6 +76,12 @@
                                     <action selector="performZoom:" target="-1" id="240"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Enter Full Screen" keyEquivalent="f" id="241">
+                                <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                <connections>
+                                    <action selector="toggleFullScreen:" target="-1" id="242"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="92">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>

--- a/appshell/mac/Info.plist
+++ b/appshell/mac/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.5.0</string>
+	<string>1.6.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.6.0</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/appshell/mac/Japanese.lproj/MainMenu.xib
+++ b/appshell/mac/Japanese.lproj/MainMenu.xib
@@ -76,6 +76,12 @@
                                     <action selector="performZoom:" target="-1" id="240"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Enter Full Screen" keyEquivalent="f" id="241">
+                                <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                <connections>
+                                    <action selector="toggleFullScreen:" target="-1" id="242"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="92">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>

--- a/appshell/version.rc
+++ b/appshell/version.rc
@@ -32,7 +32,7 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 //
 
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION    	1,5,0,0
+FILEVERSION    	1,6,0,0
 /* PRODUCTVERSION 	1,0,0,0 */
 FILEOS         	VOS__WINDOWS32
 FILETYPE       	VFT_APP
@@ -43,7 +43,7 @@ BEGIN
         BEGIN
             VALUE "CompanyName",      "brackets.io\0"
             VALUE "FileDescription",  "\0"
-            VALUE "FileVersion",      "Release 1.5.0\0"
+            VALUE "FileVersion",      "Release 1.6.0\0"
             VALUE "ProductName",      APP_NAME "\0"
             VALUE "ProductVersion",   "\0"
             VALUE "LegalCopyright",   "(c) 2012 Adobe Systems, Inc.\0"

--- a/installer/mac/buildInstaller.sh
+++ b/installer/mac/buildInstaller.sh
@@ -2,7 +2,7 @@
 
 # config
 releaseName="Brackets"
-version="1.5"
+version="1.6"
 dmgName="${releaseName} Release ${version}"
 format="bzip2"
 encryption="none"

--- a/installer/win/brackets-win-install-build.xml
+++ b/installer/win/brackets-win-install-build.xml
@@ -12,7 +12,7 @@ default="build.mul">
   <!-- See also: product name definitions in Brackets_<locale>.wxl -->
   <property name="product.shortname" value="Brackets"/>
   <property name="product.release.number.major" value="1"/>
-  <property name="product.release.number.minor" value="5"/>
+  <property name="product.release.number.minor" value="6"/>
   <property name="product.version.number" value="${product.release.number.major}.${product.release.number.minor}"/>
   <property name="product.version.name" value="Release ${product.version.number}"/>
   <property name="product.fullname" value="Brackets ${product.version.name}"/>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "Brackets-Shell",
-    "version": "1.5.0-0",
+    "version": "1.6.0-0",
     "homepage": "http://brackets.io",
     "issues": {
         "url": "http://github.com/adobe/brackets-shell/issues"


### PR DESCRIPTION
This is the fix for https://github.com/adobe/brackets/issues/11782. 

Apple mandates all applications to have "Enter Full Screen" menu which executes "toggleFullScreen:" and target as nil. Now if applications don't do that, they are going to add this menu to menubar. 

So added the a new menu "Enter Full Screen" with shortcut as Ctrl-Cmd-F. This will make sure the OS does not go about randomly assigning shortcuts to "Enter Full Screen".

Another interesting observation is the fact that, OS automatically substitutes the language equivalent of "Enter Full Screen" for the current system language, provided we have the resource files for that languages. So in our case, this menu entry is automatically translated in cases of french and jp and we have resource files for that. Unfortunately for other languages the menu is going to be in english which is the same case with "Minimize" and "Zoom" menus. It is really weird!

This is not documented and it took a while for me to figure out what is going on. 