### PR TITLE
Fix for issue #11782

### DIFF
--- a/appshell/mac/English.lproj/MainMenu.xib
+++ b/appshell/mac/English.lproj/MainMenu.xib
@@ -76,6 +76,12 @@
                                     <action selector="performZoom:" target="-1" id="240"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Enter Full Screen" keyEquivalent="f" id="241">
+                                <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                <connections>
+                                    <action selector="toggleFullScreen:" target="-1" id="242"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="92">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>

--- a/appshell/mac/French.lproj/MainMenu.xib
+++ b/appshell/mac/French.lproj/MainMenu.xib
@@ -76,6 +76,12 @@
                                     <action selector="performZoom:" target="-1" id="240"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Enter Full Screen" keyEquivalent="f" id="241">
+                                <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                <connections>
+                                    <action selector="toggleFullScreen:" target="-1" id="242"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="92">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>

--- a/appshell/mac/Japanese.lproj/MainMenu.xib
+++ b/appshell/mac/Japanese.lproj/MainMenu.xib
@@ -76,6 +76,12 @@
                                     <action selector="performZoom:" target="-1" id="240"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Enter Full Screen" keyEquivalent="f" id="241">
+                                <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                <connections>
+                                    <action selector="toggleFullScreen:" target="-1" id="242"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="92">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>


### PR DESCRIPTION
This is the fix for adobe/brackets#11782.

Apple mandates all applications to have "Enter Full Screen" menu which executes "toggleFullScreen:" and target as nil. Now if applications don't do that, they are going to add this menu to menubar.

So added the a new menu "Enter Full Screen" with shortcut as Ctrl-Cmd-F. This will make sure the OS does not go about randomly assigning shortcuts to "Enter Full Screen".

Another interesting observation is the fact that, OS automatically substitutes the language equivalent of "Enter Full Screen" for the current system language, provided we have the resource files for that languages. So in our case, this menu entry is automatically translated in cases of french and jp and we have resource files for that. Unfortunately for other languages the menu is going to be in english which is the same case with "Minimize" and "Zoom" menus. It is really weird!

This is not documented and it took a while for me to figure out what is going on.