### PR TITLE
Remove a number of unnecessary file associations

### DIFF
--- a/installer/win/Brackets.wxs
+++ b/installer/win/Brackets.wxs
@@ -50,7 +50,7 @@
                            Value="SOFTWARE\$(var.RegistryRoot)\Capabilities" Type="string" />
 
             <!-- File associations -->
-            <?define SupportedFiletypes=txt;groovy;ini;properties;css;scss;html;htm;shtm;shtml;xhtml;cfm;cfm1;cfc;dhtml;xht;tpl;twig;hbs;handlebars;kit;jsp;aspx;ejs;js;jsx;json;svg;xml;wxs;wxl;wsdl;rss;atom;rdf;xslt;xul;xbl;mathml;config;php;php3;php4;php5;phtm;phtml;ctp;c;h;i;cc;cp;cpp;c++;cxx;hh;hpp;hxx;h++;ii;cs;cshtml;asax;ashx;java;scala;sbt;coffee;cson;cf;clj;pl;pm;rb;ru;gemspec;rake;py;pyw;wsgi;sass;less;lua;sql;diff;patch;md;markdown;yaml;yml;hx;sh?>
+            <?define SupportedFiletypes=css;scss;html;htm;shtm;shtml;xhtml;cfm;cfm1;cfc;dhtml;xht;tpl;twig;hbs;handlebars;kit;jsp;aspx;ejs;js;jsx;json;svg;xml;rss;atom;rdf;xslt;xul;xbl;mathml;php;php3;php4;php5;phtm;phtml;ctp;cshtml;asax;ashx;coffee;cson;cf;clj;wsgi;sass;less;sql;diff;patch;md;markdown;yaml;yml;hx?>
 
             <?foreach filetype in $(var.SupportedFiletypes)?>
                 <!-- associate program with file type -->


### PR DESCRIPTION
Brackets is a front-end web code editor. The Windows installer, however, registers a ton of file associations that were too generic, should belong to another IDE, or were not at all related. Combined with lack of an installation option to choose what should be registered, issues such as adobe/brackets#6073 have been created.

One fix mentioned (and agreed with multiple times) is to drop the aforementioned associations from being registered. This PR does exactly that, dropping, Python C/C#/C++, Ruby, Java (and like-Java), Perl, and generic extensions (e.g., properties, ini, txt). I left PHP in-place.

With this change, the number of associations registered drops from 92 to 57. That is still a very high number and could still be lowered, but it is already a drastic improvement.