### PR TITLE
VS2015: fix some warnings

### DIFF
--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -422,66 +422,35 @@ int32 ShowOpenDialog(bool allowMultipleSelection,
     ConvertToNativePath(initialDirectory);
 
     if (chooseDirectory) {
-        // check current OS version
-        OSVERSIONINFO osvi;
-        memset(&osvi, 0, sizeof(OSVERSIONINFO));
-        osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
-        if (GetVersionEx(&osvi) && (osvi.dwMajorVersion >= 6)) {
-            // for Vista or later, use the MSDN-preferred implementation of the Open File dialog in pick folders mode
-            IFileDialog *pfd;
-            if (SUCCEEDED(CoCreateInstance(CLSID_FileOpenDialog, NULL, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&pfd)))) {
-                // configure the dialog to Select Folders only
-                DWORD dwOptions;
-                if (SUCCEEDED(pfd->GetOptions(&dwOptions))) {
-                    pfd->SetOptions(dwOptions | FOS_PICKFOLDERS | FOS_DONTADDTORECENT);
-                    IShellItem *shellItem = NULL;
-                    if (SUCCEEDED(SHCreateItemFromParsingName(initialDirectory.c_str(), 0, IID_IShellItem, reinterpret_cast<void**>(&shellItem))))
-                        pfd->SetFolder(shellItem);
-                    pfd->SetTitle(title.c_str());
-                    if (SUCCEEDED(pfd->Show(GetActiveWindow()))) {
-                        IShellItem *psi;
-                        if (SUCCEEDED(pfd->GetResult(&psi))) {
-                            LPWSTR lpwszName = NULL;
-                            if(SUCCEEDED(psi->GetDisplayName(SIGDN_DESKTOPABSOLUTEPARSING, (LPWSTR*)&lpwszName))) {
-                                // Add directory path to the result
-                                std::wstring wstrName(lpwszName);
-                                ExtensionString pathName(wstrName);
-                                ConvertToUnixPath(pathName);
-                                selectedFiles->SetString(0, pathName);
-                                ::CoTaskMemFree(lpwszName);
-                            }
-                            psi->Release();
+        IFileDialog *pfd;
+        if (SUCCEEDED(CoCreateInstance(CLSID_FileOpenDialog, NULL, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&pfd)))) {
+            // configure the dialog to Select Folders only
+            DWORD dwOptions;
+            if (SUCCEEDED(pfd->GetOptions(&dwOptions))) {
+                pfd->SetOptions(dwOptions | FOS_PICKFOLDERS | FOS_DONTADDTORECENT);
+                IShellItem *shellItem = NULL;
+                if (SUCCEEDED(SHCreateItemFromParsingName(initialDirectory.c_str(), 0, IID_IShellItem, reinterpret_cast<void**>(&shellItem))))
+                    pfd->SetFolder(shellItem);
+                pfd->SetTitle(title.c_str());
+                if (SUCCEEDED(pfd->Show(GetActiveWindow()))) {
+                    IShellItem *psi;
+                    if (SUCCEEDED(pfd->GetResult(&psi))) {
+                        LPWSTR lpwszName = NULL;
+                        if(SUCCEEDED(psi->GetDisplayName(SIGDN_DESKTOPABSOLUTEPARSING, (LPWSTR*)&lpwszName))) {
+                            // Add directory path to the result
+                            std::wstring wstrName(lpwszName);
+                            ExtensionString pathName(wstrName);
+                            ConvertToUnixPath(pathName);
+                            selectedFiles->SetString(0, pathName);
+                            ::CoTaskMemFree(lpwszName);
                         }
+                        psi->Release();
                     }
-                    if (shellItem != NULL)
-                        shellItem->Release();
                 }
-                pfd->Release();
+                if (shellItem != NULL)
+                    shellItem->Release();
             }
-        } else {
-            // for XP, use the old-styled SHBrowseForFolder() implementation
-            BROWSEINFO bi = {0};
-            bi.hwndOwner = GetActiveWindow();
-            bi.lpszTitle = title.c_str();
-            bi.ulFlags = BIF_NEWDIALOGSTYLE | BIF_EDITBOX;
-            bi.lpfn = SetInitialPathCallback;
-            bi.lParam = (LPARAM)initialDirectory.c_str();
-
-            LPITEMIDLIST pidl = SHBrowseForFolder(&bi);
-            if (pidl != 0) {
-                if (SHGetPathFromIDList(pidl, szFile)) {
-                    // Add directory path to the result
-                    ExtensionString pathName(szFile);
-                    ConvertToUnixPath(pathName);
-                    selectedFiles->SetString(0, pathName);
-                }
-                IMalloc* pMalloc = NULL;
-                SHGetMalloc(&pMalloc);
-                if (pMalloc) {
-                    pMalloc->Free(pidl);
-                    pMalloc->Release();
-                }
-            }
+            pfd->Release();
         }
     } else {
         OPENFILENAME ofn;
@@ -729,7 +698,7 @@ int32 GetFileInfo(ExtensionString filename, uint32& modtime, bool& isDir, double
 
 const int BOMLength = 3;
 
-typedef enum CheckedState { CS_UNKNOWN, CS_NO, CS_YES };
+enum CheckedState { CS_UNKNOWN, CS_NO, CS_YES };
 
 typedef struct UTFValidationState {
 

--- a/appshell/appshell_node_process_win.cpp
+++ b/appshell/appshell_node_process_win.cpp
@@ -224,7 +224,7 @@ DWORD WINAPI NodeThread(LPVOID lpParam) {
 				hNodeReadThread = CreateThread(NULL, 0, NodeReadThread, NULL, 0, NULL);
 
 				// Loop to check if process is still running
-				BOOL bSuccess = FALSE;
+				bSuccess = FALSE;
 				DWORD exitCode = 0;
 				for (;;) 
 				{	

--- a/appshell/cef_dark_aero_window.cpp
+++ b/appshell/cef_dark_aero_window.cpp
@@ -54,19 +54,12 @@ HINSTANCE CDwmDLL::LoadLibrary()
 {
     if (mhDwmDll == NULL)
     {
-        // dynamically load dwmapi.dll if running Windows Vista or later (ie. not on XP)
-        ::OSVERSIONINFO osvi = {0};
-        osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
-        ::GetVersionEx(&osvi);
-        if ((osvi.dwMajorVersion > 5) || ((osvi.dwMajorVersion == 5) && (osvi.dwMinorVersion >= 1) ))
+        mhDwmDll = ::LoadLibrary(TEXT("dwmapi.dll"));
+        if (mhDwmDll != NULL)
         {
-            mhDwmDll = ::LoadLibrary(TEXT("dwmapi.dll"));
-            if (mhDwmDll != NULL)
-            {
-                pfnDwmExtendFrameIntoClientArea = (PFNDWMEFICA)::GetProcAddress(mhDwmDll, "DwmExtendFrameIntoClientArea");
-                pfnDwmDefWindowProc = (PFNDWMDWP)::GetProcAddress(mhDwmDll, "DwmDefWindowProc");
-                pfnDwmIsCompositionEnabled = (PFNDWMICE)::GetProcAddress(mhDwmDll, "DwmIsCompositionEnabled");
-            }
+            pfnDwmExtendFrameIntoClientArea = (PFNDWMEFICA)::GetProcAddress(mhDwmDll, "DwmExtendFrameIntoClientArea");
+            pfnDwmDefWindowProc = (PFNDWMDWP)::GetProcAddress(mhDwmDll, "DwmDefWindowProc");
+            pfnDwmIsCompositionEnabled = (PFNDWMICE)::GetProcAddress(mhDwmDll, "DwmIsCompositionEnabled");
         }
     }
     return mhDwmDll;

--- a/appshell/cef_dark_window.cpp
+++ b/appshell/cef_dark_window.cpp
@@ -23,12 +23,23 @@
 #include "resource.h"
 #include <minmax.h>
 #include <objidl.h>
-#include <GdiPlus.h>
 #include <Uxtheme.h>
 #include <Shlwapi.h>
 
 #define OS_WIN
 #include "config.h"
+
+// With VS2015 including the gdiplus.h header results in many C4458 warnings.
+// Disable them.
+#ifdef _MSC_VER
+    #pragma warning(push)
+    #pragma warning(disable:4458) // declaration of 'xxx' hides class member
+#endif
+#include <GdiPlus.h>
+#ifdef _MSC_VER
+    #pragma warning(pop)
+#endif
+
 
 //win HiDPI - Macro for loading button resources for scale factors start 
 #define BUTTON_RESOURCES(scale)\

--- a/appshell/client_app.cpp
+++ b/appshell/client_app.cpp
@@ -92,9 +92,9 @@ void SetListValue(CefRefPtr<CefV8Value> list, int index,
   CefValueType type = value->GetType(index);
   switch (type) {
     case VTYPE_LIST: {
-      CefRefPtr<CefListValue> list = value->GetList(index);
-      new_value = CefV8Value::CreateArray(list->GetSize());
-      SetList(list, new_value);
+      CefRefPtr<CefListValue> listValue = value->GetList(index);
+      new_value = CefV8Value::CreateArray(listValue->GetSize());
+      SetList(listValue, new_value);
       } break;
     case VTYPE_BOOL:
       new_value = CefV8Value::CreateBool(value->GetBool(index));
@@ -347,7 +347,7 @@ bool ClientApp::OnProcessMessageReceived(
             CefRefPtr<CefListValue> messageArgs = message->GetArgumentList();
             CefString commandName = messageArgs->GetString(0);
             int messageId = messageArgs->GetSize() > 1 ? messageArgs->GetInt(1) : -1;
-            bool handled = false;
+            handled = false;
             
             StContextScope ctx(browser->GetMainFrame()->GetV8Context());
             


### PR DESCRIPTION
The warnings fixed were:
- GetVersionEx is deprecated and so will raise warning as errors. There were two case: in one it checked if on Windows Vista or later in the second if on Windows XP or later.
AFAICT the platforms supported are from Vista onwards: I removed the checks.
- GdiPlus.h inclusion will raise some warnings so I disabled them
- there were some redeclaration warnings

/cc @nethip