### PR TITLE
[MAC] Fix for open file dialog being jerky

### DIFF
--- a/appshell/appshell_extensions.cpp
+++ b/appshell/appshell_extensions.cpp
@@ -134,9 +134,8 @@ public:
                                browser,
                                response);
                 
-                // On MAC, beginModalSheet is going
-                // to inform us asynchronusly. So here return from here
-                // and delay sending the response until later.
+                // Skip standard callback handling. ShowOpenDialog fires the
+                // callback asynchronously.
                 
                 return true;
 #else
@@ -172,10 +171,8 @@ public:
                 ExtensionString proposedNewFilename = argList->GetString(3);
                 
 #ifdef OS_MACOSX
-                // ShowSaveDialog itself is going to
-                // take of communicating with the
-                // render process.
-                
+                // Skip standard callback handling. ShowSaveDialog fires the
+                // callback asynchronously.
                 ShowSaveDialog(title,
                                initialPath,
                                proposedNewFilename,

--- a/appshell/appshell_extensions.cpp
+++ b/appshell/appshell_extensions.cpp
@@ -117,8 +117,6 @@ public:
                 argList->GetType(5) != VTYPE_STRING) {
                 error = ERR_INVALID_PARAMS;
             }
-
-            CefRefPtr<CefListValue> selectedFiles = CefListValue::Create();
            
             if (error == NO_ERROR) {
                 bool allowMultipleSelection = argList->GetBool(1);
@@ -127,16 +125,34 @@ public:
                 ExtensionString initialPath = argList->GetString(4);
                 ExtensionString fileTypes = argList->GetString(5);
                 
+#ifdef OS_MACOSX
+                ShowOpenDialog(allowMultipleSelection,
+                               chooseDirectory,
+                               title,
+                               initialPath,
+                               fileTypes,
+                               browser,
+                               response);
+                
+                // On MAC, beginModalSheet is going
+                // to inform us asynchronusly. So here return from here
+                // and delay sending the response until later.
+                
+                return true;
+#else
+                CefRefPtr<CefListValue> selectedFiles = CefListValue::Create();
                 error = ShowOpenDialog(allowMultipleSelection,
                                        chooseDirectory,
                                        title,
                                        initialPath,
                                        fileTypes,
                                        selectedFiles);
+                // Set response args for this function
+                responseArgs->SetList(2, selectedFiles);
+#endif
+                
             }
-
-            // Set response args for this function
-            responseArgs->SetList(2, selectedFiles);
+            
         } else if (message_name == "ShowSaveDialog") {
             // Parameters:
             //  0: int32 - callback id
@@ -150,21 +166,34 @@ public:
                 error = ERR_INVALID_PARAMS;
             }
 
-            ExtensionString newFilePath;
-
             if (error == NO_ERROR) {
                 ExtensionString title = argList->GetString(1);
                 ExtensionString initialPath = argList->GetString(2);
                 ExtensionString proposedNewFilename = argList->GetString(3);
-
+                
+#ifdef OS_MACOSX
+                // ShowSaveDialog itself is going to
+                // take of communicating with the
+                // render process.
+                
+                ShowSaveDialog(title,
+                               initialPath,
+                               proposedNewFilename,
+                               browser,
+                               response);
+                return true;
+#else
+                ExtensionString newFilePath;
                 error = ShowSaveDialog(title,
-                                         initialPath,
-                                         proposedNewFilename,
-                                         newFilePath);
+                                       initialPath,
+                                       proposedNewFilename,
+                                       newFilePath);
+                
+                // Set response args for this function
+                responseArgs->SetString(2, newFilePath);
+#endif
             }
 
-            // Set response args for this function
-            responseArgs->SetString(2, newFilePath);
         } else if (message_name == "IsNetworkDrive") {
             // Parameters:
             //  0: int32 - callback id

--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -51,6 +51,27 @@ int const debugPort = 9222;
 NSString* debugPortCommandlineArguments = [NSString stringWithFormat:@"--remote-debugging-port=%d", debugPort];
 NSString* debugProfilePath = [NSString stringWithFormat:@"--user-data-dir=%s/live-dev-profile", ClientApp::AppGetSupportDirectory().ToString().c_str()];
 
+// These are required for [NSSavePanel beginSheetModalForWindow]
+// We need to store the panel to browser details
+// in a map as that could be the panel is the only
+// variable accessible inside the completionHandler
+// block. Also the map is neccessary for handling
+// reentrant scenarios. E.g.file open/save dialog could
+// be requested from from multiple Brackets windows.
+// Earlier RunModal was making sure none of the opened
+// NSWindows are clickable when running the runModal of
+// the modal sheet. With completionHandler coming into
+// picture, that is not the case anymore.
+
+struct CefBrowserDetails
+{
+    CefRefPtr<CefProcessMessage> m_response;
+    CefRefPtr<CefBrowser>        m_browser;
+};
+
+static  std::map<NSSavePanel *, CefBrowserDetails>           s_panel_to_browser;
+typedef std::map<NSSavePanel *, CefBrowserDetails>::iterator panel_iterator;
+
 ///////////////////////////////////////////////////////////////////////////////
 // LiveBrowserMgrMac
 
@@ -375,12 +396,13 @@ int32 OpenURLInDefaultBrowser(ExtensionString url)
     return NO_ERROR;
 }
 
-int32 ShowOpenDialog(bool allowMulitpleSelection,
+void ShowOpenDialog(bool allowMulitpleSelection,
                      bool chooseDirectory,
                      ExtensionString title,
                      ExtensionString initialDirectory,
                      ExtensionString fileTypes,
-                     CefRefPtr<CefListValue>& selectedFiles)
+                     CefRefPtr<CefBrowser> browser,
+                     CefRefPtr<CefProcessMessage> response)
 {
     NSArray* allowedFileTypes = nil;
     BOOL canChooseDirectories = chooseDirectory;
@@ -408,23 +430,48 @@ int32 ShowOpenDialog(bool allowMulitpleSelection,
     
     [openPanel setAllowedFileTypes:allowedFileTypes];
     
-    [openPanel beginSheetModalForWindow:[NSApp mainWindow] completionHandler:nil];
-    if ([openPanel runModal] == NSOKButton)
-    {
-        NSArray* urls = [openPanel URLs];
-        for (NSUInteger i = 0; i < [urls count]; i++) {
-            selectedFiles->SetString(i, [[[urls objectAtIndex:i] path] UTF8String]);
-        }
-    }
-    [NSApp endSheet:openPanel];
+    // cache the browser details, so has to access
+    // the same inside the completionHandler block.
+    CefBrowserDetails browserDetails;
+    browserDetails.m_browser  = browser;
+    browserDetails.m_response = response;
     
-    return NO_ERROR;
+    s_panel_to_browser[openPanel] = browserDetails;
+    
+    [openPanel beginSheetModalForWindow:[NSApp mainWindow] completionHandler: ^(NSInteger returnCode)
+    {
+        panel_iterator _browserDetails;
+        _browserDetails = s_panel_to_browser.find(openPanel);
+        if(_browserDetails != s_panel_to_browser.end()){
+            
+            CefRefPtr<CefProcessMessage> _response = _browserDetails->second.m_response;
+            CefRefPtr<CefBrowser>        _browser  = _browserDetails->second.m_browser;
+            
+            if(_response && _browser){
+
+                NSArray *urls = [openPanel URLs];
+                CefRefPtr<CefListValue> selectedFiles = CefListValue::Create();
+                if (returnCode == NSModalResponseOK){
+                    for (NSUInteger i = 0; i < [urls count]; i++) {
+                        selectedFiles->SetString(i, [[[urls objectAtIndex:i] path] UTF8String]);
+                    }
+                }
+
+                // Set common response args (error and selectedfiles list)
+                _response->GetArgumentList()->SetInt(1, NO_ERROR);
+                _response->GetArgumentList()->SetList(2, selectedFiles);
+                _browser->SendProcessMessage(PID_RENDERER, _response);
+            }
+            s_panel_to_browser.erase(_browserDetails);
+        }
+    }];
 }
 
-int32 ShowSaveDialog(ExtensionString title,
+void ShowSaveDialog(ExtensionString title,
                        ExtensionString initialDirectory,
                        ExtensionString proposedNewFilename,
-                       ExtensionString& absoluteFilepath)
+                       CefRefPtr<CefBrowser> browser,
+                       CefRefPtr<CefProcessMessage> response)
 {
     NSSavePanel* savePanel = [NSSavePanel savePanel];
     [savePanel setTitle: [NSString stringWithUTF8String:title.c_str()]];
@@ -436,17 +483,39 @@ int32 ShowSaveDialog(ExtensionString title,
     }
 
     [savePanel setNameFieldStringValue:[NSString stringWithUTF8String:proposedNewFilename.c_str()]];
-    [savePanel beginSheetModalForWindow:[NSApp mainWindow] completionHandler:nil];
+
+    // cache the browser details, so has to access
+    // the same inside the completionHandler block.
+    CefBrowserDetails browserDetails;
+    browserDetails.m_browser  = browser;
+    browserDetails.m_response = response;
     
-    if ([savePanel runModal] == NSFileHandlingPanelOKButton)
-    {
-        NSURL* theFile = [savePanel URL];
-        absoluteFilepath = [[theFile path] UTF8String];
+    s_panel_to_browser[savePanel] = browserDetails;
+    
+    [savePanel beginSheetModalForWindow:[NSApp mainWindow] completionHandler: ^(NSInteger returnCode)
+     {
+         panel_iterator _browserDetails;
+         _browserDetails = s_panel_to_browser.find(savePanel);
+         if(_browserDetails != s_panel_to_browser.end()){
+             
+             CefRefPtr<CefProcessMessage> _response = _browserDetails->second.m_response;
+             CefRefPtr<CefBrowser>        _browser  = _browserDetails->second.m_browser;
+             
+             if(_response && _browser){
 
-    }
-    [NSApp endSheet:savePanel];
+                 NSURL* selectedFile = nil;
+                 if (returnCode == NSOKButton){
+                     selectedFile = [savePanel URL];
+                 }
 
-    return NO_ERROR;
+                 // Set common response args (error and the new file name string)
+                 _response->GetArgumentList()->SetInt(1, NO_ERROR);
+                 _response->GetArgumentList()->SetString(2, [[selectedFile path] UTF8String]);
+                 _browser->SendProcessMessage(PID_RENDERER, _response);
+             }
+         }
+
+     }];
 }
 
 int32 IsNetworkDrive(ExtensionString path, bool& isRemote)

--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -409,8 +409,8 @@ void ShowOpenDialog(bool allowMulitpleSelection,
     
     [openPanel setAllowedFileTypes:allowedFileTypes];
     
-    // cache the browser details, so has to access
-    // the same inside the completionHandler block.
+    // cache the browser and response variables, so that these
+    // can be accessed from within the completionHandler block.
     CefRefPtr<CefBrowser>        _browser  = browser;
     CefRefPtr<CefProcessMessage> _response = response;
 
@@ -451,8 +451,8 @@ void ShowSaveDialog(ExtensionString title,
 
     [savePanel setNameFieldStringValue:[NSString stringWithUTF8String:proposedNewFilename.c_str()]];
 
-    // cache the browser details, so has to access
-    // the same inside the completionHandler block.
+    // cache the browser and response variables, so that these
+    // can be accessed from within the completionHandler block.
     CefRefPtr<CefBrowser>        _browser  = browser;
     CefRefPtr<CefProcessMessage> _response = response;
 

--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -460,14 +460,16 @@ void ShowSaveDialog(ExtensionString title,
     {
          if(_response && _browser){
 
-             NSURL* selectedFile = nil;
+             CefString pathStr;
              if (returnCode == NSModalResponseOK){
-                 selectedFile = [savePanel URL];
+                 NSURL* selectedFile = [savePanel URL];
+                 if(selectedFile)
+                     pathStr = [[selectedFile path] UTF8String];
              }
 
              // Set common response args (error and the new file name string)
              _response->GetArgumentList()->SetInt(1, NO_ERROR);
-             _response->GetArgumentList()->SetString(2, [[selectedFile path] UTF8String]);
+             _response->GetArgumentList()->SetString(2, pathStr);
              _browser->SendProcessMessage(PID_RENDERER, _response);
          }
     }];

--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -461,7 +461,7 @@ void ShowSaveDialog(ExtensionString title,
          if(_response && _browser){
 
              NSURL* selectedFile = nil;
-             if (returnCode == NSOKButton){
+             if (returnCode == NSModalResponseOK){
                  selectedFile = [savePanel URL];
              }
 

--- a/appshell/appshell_extensions_platform.h
+++ b/appshell/appshell_extensions_platform.h
@@ -86,6 +86,7 @@ void CloseLiveBrowser(CefRefPtr<CefBrowser> browser, CefRefPtr<CefProcessMessage
 
 int32 OpenURLInDefaultBrowser(ExtensionString url);
 
+#ifndef OS_MACOSX
 int32 ShowOpenDialog(bool allowMulitpleSelection,
                      bool chooseDirectory,
                      ExtensionString title,
@@ -97,6 +98,21 @@ int32 ShowSaveDialog(ExtensionString title,
                        ExtensionString initialDirectory,
                        ExtensionString proposedNewFilename,
                        ExtensionString& newFilePath);
+#else
+void ShowOpenDialog(bool allowMulitpleSelection,
+                     bool chooseDirectory,
+                     ExtensionString title,
+                     ExtensionString initialDirectory,
+                     ExtensionString fileTypes,
+                     CefRefPtr<CefBrowser> browser,
+                     CefRefPtr<CefProcessMessage> response);
+
+void ShowSaveDialog(ExtensionString title,
+                     ExtensionString initialDirectory,
+                     ExtensionString proposedNewFilename,
+                     CefRefPtr<CefBrowser> browser,
+                     CefRefPtr<CefProcessMessage> response);
+#endif
 
 int32 IsNetworkDrive(ExtensionString path, bool& isRemote);
 

--- a/appshell/client_handler_mac.mm
+++ b/appshell/client_handler_mac.mm
@@ -61,6 +61,8 @@ void ClientHandler::OnTitleChange(CefRefPtr<CefBrowser> browser,
   if ([window styleMask] & NSFullScreenWindowMask) {
       [window setTitle:str];
   }
+    
+  [NSApp changeWindowsItem:window title:str filename:NO];
 
   [delegate performSelectorOnMainThread:@selector(windowTitleDidChange:) withObject:str waitUntilDone:NO];
 }

--- a/appshell/client_handler_mac.mm
+++ b/appshell/client_handler_mac.mm
@@ -61,11 +61,13 @@ void ClientHandler::OnTitleChange(CefRefPtr<CefBrowser> browser,
   if ([window styleMask] & NSFullScreenWindowMask) {
       [window setTitle:str];
   }
-    
-  // This is required as we are now managing the window title
-  // on our own, because of which the window title entires 
-  // are not getting added to 'Windows' menu. This is an
-  // an official API.
+    // This is required as we are now managing the window's title
+    // on our own, using CustomTitlbeBarView. As we are nuking the
+    // window's title, currently open windows like new brackets
+    // windows/dev tools are not getting listed under the
+    // 'Window' menu. So we are now explicitly telling OS to make
+    // sure we have a menu entry under 'Window' menu. This is a
+    // safe call and is officially supported.
   [NSApp changeWindowsItem:window title:str filename:NO];
 
   [delegate performSelectorOnMainThread:@selector(windowTitleDidChange:) withObject:str waitUntilDone:NO];


### PR DESCRIPTION
This PR addresses the following items.

 - The file open/save dialog jerks a bit when launched from Brackets. The reason for that being we are not honouring the `completionHandler` semantics, when launching the dialog using `beginSheetModalForWindow`. After installing `completionHandler` block, I realised it is not straight forward, as we would have returning by then. So had to make changes which involved caching the reference of the browser, so that the same could be used inside the `completionHandler` block. Also took care of re-entrant scenarios by using a map, to cache the requests and send the response to the right corresponding browser.

 - When multiple windows like, new brackets window, or devtools, were open, the entries were missing from the *Window* menu. So made sure, we have a menu entry for all open windows under *Windows* menu on MAC.
