### PR TITLE
Update Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -115,6 +115,8 @@ module.exports = function (grunt) {
                             "devtools_resources.pak",
                             "icudtl.dat",
                             "libcef.dll",
+                            "natives_blob.bin",
+                            "snapshot_blob.bin",
                             "command/**"
                         ],
                         "dest"      : "installer/win/staging/"


### PR DESCRIPTION
The two files `natives_blob.bin` and `snapshot_blob.bin` are not getting copied to the stage for creating the installer.

Tagging @swmitra 