### PR TITLE
Enable paste command

### DIFF
--- a/appshell/cef_main_window.cpp
+++ b/appshell/cef_main_window.cpp
@@ -226,6 +226,10 @@ BOOL cef_main_window::HandleCreate()
 
     settings.web_security = STATE_DISABLED;
 
+    // Necessary to enable document.executeCommand("paste")
+    settings.javascript_access_clipboard = STATE_ENABLED;
+    settings.javascript_dom_paste = STATE_ENABLED;
+
     // Initialize window info to the defaults for a child window
     info.SetAsChild(mWnd, rect);
 

--- a/appshell/cefclient_gtk.cpp
+++ b/appshell/cefclient_gtk.cpp
@@ -244,6 +244,10 @@ int main(int argc, char* argv[]) {
 
   browserSettings.web_security = STATE_DISABLED;
 
+  // Necessary to enable document.executeCommand("paste")
+  browserSettings.javascript_access_clipboard = STATE_ENABLED;
+  browserSettings.javascript_dom_paste = STATE_ENABLED;
+
   window_info.SetAsChild(vbox);
 
   CefBrowserHost::CreateBrowser(

--- a/appshell/cefclient_mac.mm
+++ b/appshell/cefclient_mac.mm
@@ -682,6 +682,10 @@ extern NSMutableArray* pendingOpenFiles;
 
   settings.web_security = STATE_DISABLED;
 
+  // Necessary to enable document.executeCommand("paste")
+  settings.javascript_access_clipboard = STATE_ENABLED;
+  settings.javascript_dom_paste = STATE_ENABLED;
+
   CefRefPtr<CefCommandLine> cmdLine = AppGetCommandLine();
 
 #ifdef DARK_INITIAL_PAGE


### PR DESCRIPTION
With this we can now use `document.execCommand("paste")`
While testing Ubuntu 16.04 seems this change is unnecessary so I didn't write a PR for the `linux-1547` branch. 
OSX is untested.
On the web there are some security risk but I don't think for and editor it's the same.
Plus looking around seems VSCode [use](https://github.com/Microsoft/vscode/blob/050622610dad12457040f2eff7f5af1174a08ffe/src/vs/editor/contrib/clipboard/browser/clipboard.ts) that command too.