### PR TITLE
Update, and made works, build_projects.bat

### DIFF
--- a/scripts/build_projects.bat
+++ b/scripts/build_projects.bat
@@ -1,13 +1,23 @@
 :: Batch file that sets up Visual Studio command line tools and builds appshell.sln
 :: This file should *not* be called directly. It is called by the build.sh script.
-ECHO OFF
+@ECHO OFF
 
+IF DEFINED VS140COMNTOOLS GOTO VS2015
+IF DEFINED VS120COMNTOOLS GOTO VS2013
 IF DEFINED VS110COMNTOOLS GOTO VS2012
 IF DEFINED VS100COMNTOOLS GOTO VS2010
 
 :VSNotInstalled
-ECHO Visual Studio 2010 or 2012 must be installed.
-GOTO Exit
+ECHO Visual Studio 2010, 2012, 2013 or 2015 must be installed.
+GOTO Error
+
+:VS2015
+call "%VS140COMNTOOLS%/vsvars32.bat"
+GOTO Build
+
+:VS2013
+call "%VS120COMNTOOLS%/vsvars32.bat"
+GOTO Build
 
 :VS2012
 call "%VS110COMNTOOLS%/vsvars32.bat"
@@ -18,8 +28,9 @@ call "%VS100COMNTOOLS%/vsvars32.bat"
 GOTO Build
 
 :Build
-msbuild.exe appshell.sln /t:Clean /p:Platform=Win32 /p:Configuration=Release
-msbuild.exe appshell.sln /t:Build /p:Platform=Win32 /p:Configuration=Release
-
-:Exit
+msbuild.exe appshell.sln /nr:false /t:Clean /p:Platform=Win32 /p:Configuration=Release
+msbuild.exe appshell.sln /nr:false /t:Build /p:Platform=Win32 /p:Configuration=Release
 exit /b %ERRORLEVEL%
+
+:Error
+exit /b 1


### PR DESCRIPTION
I found that this script was actually failing for me with `Visual Studio 2010 or 2012 must be installed.` but the script was exiting with 0 code so the error was actually hidden. (I noticed this script looking at #440)
Given that I'm not even sure if this serve a real purpose and probably I'm doing something wrong, or at least I hope, because now the `build-win` step is a lot slower.
