### PR TITLE
Add client_types.h, match gtk gyp inclusion of cefclient

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -158,7 +158,10 @@ module.exports = function (grunt) {
                             "Brackets",
                             "Brackets-node",
                             "cef.pak",
-                            "devtools_resources.pak"
+                            "cef_100_percent.pak",
+                            "cef_200_percent.pak",
+                            "devtools_resources.pak",
+                            "icudtl.dat",
                         ],
                         "dest"      : "<%= build.staging %>"
                     },

--- a/appshell.gyp
+++ b/appshell.gyp
@@ -315,15 +315,25 @@
           },
           'copies': [
             {
-              'destination': '<(PRODUCT_DIR)/lib',
+              'destination': '<(PRODUCT_DIR)/files',
               'files': [
-                '<@(appshell_bundle_libraries_linux)',
+                '<@(appshell_bundle_resources_linux)',
               ],
             },
             {
-              'destination': '<(PRODUCT_DIR)',
+              'destination': '<(PRODUCT_DIR)/',
               'files': [
-                '<@(appshell_bundle_resources_linux)'
+                'Resources/cef.pak',
+                'Resources/cef_100_percent.pak',
+                'Resources/cef_200_percent.pak',
+                'Resources/cef_extensions.pak',
+                'Resources/devtools_resources.pak',
+                'Resources/icudtl.dat',
+                'Resources/locales/',
+                '$(BUILDTYPE)/chrome-sandbox',
+                '$(BUILDTYPE)/libcef.so',
+                '$(BUILDTYPE)/natives_blob.bin',
+                '$(BUILDTYPE)/snapshot_blob.bin',
               ],
             },
             {
@@ -340,15 +350,17 @@
               'files': ['appshell/node-core/'],
             },
           ],
+          'dependencies': [
+            'gtk',
+          ],
           'link_settings': {
             'ldflags': [
-              '<!@(<(pkg-config) --libs-only-other gtk+-2.0 gthread-2.0)',
               '-Wl,-rpath,\$$ORIGIN/lib',
               '<(march)'
             ],
             'libraries': [
-              '<!@(<(pkg-config) --libs-only-l gtk+-2.0 gthread-2.0)',
-              '$(BUILDTYPE)/libcef.so',
+              "$(BUILDTYPE)/libcef.so",
+              "-lX11",
               'appshell_extensions_js.o',
             ],
           },
@@ -392,8 +404,7 @@
       'conditions': [
         ['OS=="linux"', {
           'cflags': [
-          '<!@(<(pkg-config) --cflags gtk+-2.0 gthread-2.0)',
-          '<(march)',
+            '<(march)',
           ],
           'default_configuration': 'Release',
           'configurations': {
@@ -504,6 +515,32 @@
         },  # target appshell_helper_app
       ],
     }],  # OS=="mac"
+    [ 'OS=="linux" or OS=="freebsd" or OS=="openbsd"', {
+      'targets': [
+        {
+          'target_name': 'gtk',
+          'type': 'none',
+          'variables': {
+            # gtk requires gmodule, but it does not list it as a dependency
+            # in some misconfigured systems.
+            'gtk_packages': 'gmodule-2.0 gtk+-2.0 gthread-2.0 gtk+-unix-print-2.0',
+          },
+          'direct_dependent_settings': {
+            'cflags': [
+              '$(shell <(pkg-config) --cflags <(gtk_packages))',
+            ],
+          },
+          'link_settings': {
+            'ldflags': [
+              '$(shell <(pkg-config) --libs-only-L --libs-only-other <(gtk_packages))',
+            ],
+            'libraries': [
+              '$(shell <(pkg-config) --libs-only-l <(gtk_packages))',
+            ],
+          },
+        },
+      ],
+    }],  # OS=="linux" or OS=="freebsd" or OS=="openbsd"
     ['target_arch=="ia32"', {
       'variables': {
         'output_bfd': 'elf32-i386',

--- a/appshell/browser/client_types.h
+++ b/appshell/browser/client_types.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2015 The Chromium Embedded Framework Authors. All rights
+// reserved. Use of this source code is governed by a BSD-style license that
+// can be found in the LICENSE file.
+
+#ifndef CEF_TESTS_CEFCLIENT_BROWSER_CLIENT_TYPES_H_
+#define CEF_TESTS_CEFCLIENT_BROWSER_CLIENT_TYPES_H_
+#pragma once
+
+#include "include/cef_base.h"
+
+#if defined(OS_LINUX)
+#include <gtk/gtk.h>
+
+// The Linux client uses GTK instead of the underlying platform type (X11).
+#define ClientWindowHandle GtkWidget*
+#else
+#define ClientWindowHandle CefWindowHandle
+#endif
+
+#if defined(OS_MACOSX)
+// Forward declaration of ObjC types used by cefclient and not provided by
+// include/internal/cef_types_mac.h.
+#ifdef __cplusplus
+#ifdef __OBJC__
+@class NSWindow;
+#else
+class NSWindow;
+#endif
+#endif
+#endif  // defined OS_MACOSX
+
+#endif  // CEF_TESTS_CEFCLIENT_BROWSER_CLIENT_TYPES_H_
+

--- a/appshell/client_app_gtk.cpp
+++ b/appshell/client_app_gtk.cpp
@@ -26,6 +26,7 @@
 #include "include/cef_base.h"
 #include "config.h"
 
+#include <gtk/gtk.h>
 #include <pwd.h>
 #include <algorithm>
 //#include <MMSystem.h>

--- a/appshell_paths.gypi
+++ b/appshell_paths.gypi
@@ -140,6 +140,7 @@
       '<@(autogen_client_side)',
     ],
     'appshell_sources_browser': [
+      'appshell/browser/client_types.h',
       'appshell/browser/resource.h',
       'appshell/browser/resource_util.h',
     ],
@@ -328,17 +329,11 @@
       '<@(appshell_sources_renderer)',
     ],
     'appshell_bundle_resources_linux': [
-      'Resources/locales',
       'appshell/res/appshell32.png',
       'appshell/res/appshell48.png',
       'appshell/res/appshell128.png',
       'appshell/res/appshell256.png',
-      'Resources/cef.pak',
-      'Resources/devtools_resources.pak',
       '<@(appshell_sources_resources)',
-    ],
-    'appshell_bundle_libraries_linux': [
-      '$(BUILDTYPE)/libcef.so',
     ],
   },
 }

--- a/appshell_paths.gypi
+++ b/appshell_paths.gypi
@@ -144,7 +144,7 @@
       'appshell/browser/resource.h',
       'appshell/browser/resource_util.h',
     ],
-    'appshell_sources_common': [
+    'appshell_sources_common_helper': [
       'appshell/common/client_switches.cc',
       'appshell/common/client_switches.h',
       'appshell/appshell_extensions.cpp',
@@ -156,8 +156,6 @@
       'appshell/appshell_node_process.cpp',
       'appshell/command_callbacks.h',
       'appshell/config.h',
-      'appshell/cefclient.cpp',
-      'appshell/cefclient.h',
       'appshell/client_app.cpp',
       'appshell/client_app.h',
       'appshell/client_app_delegates.cpp',
@@ -165,6 +163,11 @@
       'appshell/client_handler.h',
       'appshell/native_menu_model.cpp',
       'appshell/native_menu_model.h',
+    ],
+    'appshell_sources_common': [
+      'appshell/cefclient.cpp',
+      'appshell/cefclient.h',
+      '<@(appshell_sources_common_helper)',
     ],
     'appshell_sources_renderer': [
     ],
@@ -258,7 +261,7 @@
       'appshell/client_app_mac.mm',
       'appshell/client_handler_mac.mm',
       'appshell/process_helper_mac.cpp',
-      '<@(appshell_sources_common)',
+      '<@(appshell_sources_common_helper)',
       '<@(appshell_sources_renderer)',
     ],
     'appshell_bundle_resources_mac': [


### PR DESCRIPTION
This is a really small step forward for Linux, I still cannot compile.
(And still hit https://github.com/adobe/brackets-shell/pull/562)