### PR TITLE
Remove define OS_*

### DIFF
--- a/appshell/appshell_extensions.cpp
+++ b/appshell/appshell_extensions.cpp
@@ -25,6 +25,7 @@
 #include "appshell_extensions_platform.h"
 #include "native_menu_model.h"
 #include "appshell_node_process.h"
+#include "config.h"
 
 #include <algorithm>
 

--- a/appshell/appshell_extensions_platform.h
+++ b/appshell/appshell_extensions_platform.h
@@ -28,6 +28,8 @@
 
 #include <string>
 
+#include "config.h"
+
 // Extension error codes. These MUST be in sync with the error
 // codes in appshell_extensions.js
 #if !defined(OS_WIN) // NO_ERROR is defined on windows

--- a/appshell/appshell_node_process_linux.cpp
+++ b/appshell/appshell_node_process_linux.cpp
@@ -34,9 +34,6 @@
 #include <sys/wait.h>
 
 
-#ifndef OS_LINUX
-#define OS_LINUX 1
-#endif
 #include "config.h"
 
 #define BRACKETS_NODE_BUFFER_SIZE 4096

--- a/appshell/appshell_node_process_win.cpp
+++ b/appshell/appshell_node_process_win.cpp
@@ -30,9 +30,6 @@
 
 #include <strsafe.h> // must be included after STL headers
 
-#ifndef OS_WIN
-#define OS_WIN 1
-#endif
 #include "config.h"
 
 #define BRACKETS_NODE_BUFFER_SIZE 4096

--- a/appshell/cef_dark_window.cpp
+++ b/appshell/cef_dark_window.cpp
@@ -26,7 +26,6 @@
 #include <Uxtheme.h>
 #include <Shlwapi.h>
 
-#define OS_WIN
 #include "config.h"
 
 // With VS2015 including the gdiplus.h header results in many C4458 warnings.

--- a/appshell/cef_registry.cpp
+++ b/appshell/cef_registry.cpp
@@ -21,10 +21,6 @@
  */
 #include <windows.h>
 
-#ifndef OS_WIN
-#define OS_WIN 1
-#endif
-
 #include "config.h"
 #include "include/base/cef_logging.h"
 

--- a/appshell/cefclient.rc
+++ b/appshell/cefclient.rc
@@ -11,7 +11,6 @@
 #include "windows.h"
 #undef APSTUDIO_HIDDEN_SYMBOLS
 
-#define OS_WIN
 #include "config.h"
 
 /////////////////////////////////////////////////////////////////////////////

--- a/appshell/client_handler.cpp
+++ b/appshell/client_handler.cpp
@@ -14,7 +14,7 @@
 #include "appshell/browser/resource_util.h"
 #include "appshell/appshell_extensions.h"
 #include "appshell/command_callbacks.h"
-
+#include "config.h"
 
 // Custom menu command Ids.
 enum client_menu_ids {

--- a/appshell/client_handler_mac.mm
+++ b/appshell/client_handler_mac.mm
@@ -1,7 +1,6 @@
 // Copyright (c) 2011 The Chromium Embedded Framework Authors. All rights
 // reserved. Use of this source code is governed by a BSD-style license that
 // can be found in the LICENSE file.
-#define OS_MAC
 
 #import <Cocoa/Cocoa.h>
 #import <objc/runtime.h>

--- a/appshell/client_handler_win.cpp
+++ b/appshell/client_handler_win.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2011 The Chromium Embedded Framework Authors. All rights
 // reserved. Use of this source code is governed by a BSD-style license that
 // can be found in the LICENSE file.
-#define OS_WIN
+
 #include "config.h"
 #include "client_handler.h"
 #include <string>

--- a/appshell/command_callbacks.h
+++ b/appshell/command_callbacks.h
@@ -2,6 +2,7 @@
 
 #include "include/cef_browser.h"
 #include "appshell_extensions_platform.h"
+#include "config.h"
 
 // Command names. These MUST be in sync with the command names in
 // brackets/src/command/Commands.js

--- a/appshell/native_menu_model.cpp
+++ b/appshell/native_menu_model.cpp
@@ -21,6 +21,7 @@
  */
 #include "native_menu_model.h"
 #include "command_callbacks.h"
+#include "config.h"
 
 #if defined(OS_WIN)
 const ExtensionString WINDOW_COMMAND    = L"window";

--- a/appshell/version.rc
+++ b/appshell/version.rc
@@ -11,7 +11,6 @@
 #include "windows.h"
 #undef APSTUDIO_HIDDEN_SYMBOLS
 
-#define OS_WIN
 #include "config.h"
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Now they are always checked in `config.h` and I made sure is always included in Brackets specific files that use those macros.