### PR TITLE
Ignore only toplevel folder and add out folder too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,13 +32,14 @@ xcodebuild/*
 *.log
 *.dmg
 
-Debug
-Release
-Resources
-deps
-include
+/Debug
+/Release
+/Resources
+/deps
+/include
 ipch
-libcef_dll
+/libcef_dll
+/out
 tools
 
 /installer/mac/staging/


### PR DESCRIPTION
I was trying to add a folder with name `resources` when I noticed this.
On Linux an `out` folder is created when building.
I didn't made `ipch` and `tools` only toplevel because I don't know what are used for.