### PR TITLE
Use again clienthandler to show devtools

### DIFF
--- a/appshell/appshell_extensions.cpp
+++ b/appshell/appshell_extensions.cpp
@@ -386,13 +386,7 @@ public:
             }
         } else if (message_name == "ShowDeveloperTools") {
             // Parameters - none
-            CefWindowInfo wi;
-            CefBrowserSettings settings;
-
-#if defined(OS_WIN)
-            wi.SetAsPopup(NULL, "DevTools");
-#endif
-            browser->GetHost()->ShowDevTools(wi, browser->GetHost()->GetClient(), settings, CefPoint());
+            handler->ShowDevTools(browser);
 
         } else if (message_name == "GetNodeState") {
             // Parameters:


### PR DESCRIPTION
The current code will crash on the cefclient example code in 2623.
It seems to me the code was changed to workaround a bug in CEF, so this actually restore a previous behaviour.
