### PR TITLE
Move fixupKey where it is used and fix headers inclusion

### DIFF
--- a/appshell/appshell_extensions.cpp
+++ b/appshell/appshell_extensions.cpp
@@ -774,15 +774,4 @@ void CreateProcessMessageDelegates(ClientHandler::ProcessMessageDelegateSet& del
     delegates.insert(new ProcessMessageDelegate);
 }
 
-//Replace keyStroke with replaceString 
-bool fixupKey(ExtensionString& key, ExtensionString keyStroke, ExtensionString replaceString)
-{
-	size_t idx = key.find(keyStroke, 0);
-	if (idx != ExtensionString::npos) {
-		key = key.replace(idx, keyStroke.size(), replaceString);
-		return true;
-	}
-	return false;
-}
-
 } // namespace appshell_extensions

--- a/appshell/appshell_extensions.h
+++ b/appshell/appshell_extensions.h
@@ -31,7 +31,4 @@ namespace appshell_extensions {
 // Create message delegates that run in the browser process
 void CreateProcessMessageDelegates(ClientHandler::ProcessMessageDelegateSet& delegates);
 
-//Replace keyStroke with replaceString 
-bool fixupKey(ExtensionString& key, ExtensionString keyStroke, ExtensionString replaceString);
-
 }  // namespace appshell_extensions

--- a/appshell/appshell_extensions_gtk.cpp
+++ b/appshell/appshell_extensions_gtk.cpp
@@ -22,7 +22,6 @@
  */
 
 #include "appshell_extensions_platform.h"
-#include "appshell_extensions.h"
 
 #include "client_app.h"
 #include <glib.h>

--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -22,8 +22,8 @@
  */
 
 #include "appshell_extensions_platform.h"
-#include "appshell_extensions.h"
 
+#include "client_app.h"
 #include "native_menu_model.h"
 
 #include "GoogleChrome.h"
@@ -1053,6 +1053,17 @@ int32 AddMenu(CefRefPtr<CefBrowser> browser, ExtensionString itemTitle, Extensio
     return errCode;
 }
 
+// Replace keyStroke with replaceString
+bool fixupKey(ExtensionString& key, ExtensionString keyStroke, ExtensionString replaceString)
+{
+    size_t idx = key.find(keyStroke, 0);
+    if (idx != ExtensionString::npos) {
+        key = key.replace(idx, keyStroke.size(), replaceString);
+        return true;
+    }
+    return false;
+}
+
 // Looks at modifiers and special keys in "key",
 // removes then and returns an unsigned int mask
 // that can be used by setKeyEquivalentModifierMask
@@ -1063,17 +1074,17 @@ NSUInteger processKeyString(ExtensionString& key)
         return 0;
     }
     NSUInteger mask = 0;
-    if (appshell_extensions::fixupKey(key, "Cmd-", "")) {
+    if (fixupKey(key, "Cmd-", "")) {
         mask |= NSCommandKeyMask;
     }
-    if (appshell_extensions::fixupKey(key, "Ctrl-", "")) {
+    if (fixupKey(key, "Ctrl-", "")) {
         mask |= NSControlKeyMask;
     }
-    if (appshell_extensions::fixupKey(key, "Shift-", "")) {
+    if (fixupKey(key, "Shift-", "")) {
         mask |= NSShiftKeyMask;
     }
-    if (appshell_extensions::fixupKey(key, "Alt-", "") ||
-        appshell_extensions::fixupKey(key, "Opt-", "")) {
+    if (fixupKey(key, "Alt-", "") ||
+        fixupKey(key, "Opt-", "")) {
         mask |= NSAlternateKeyMask;
     }
 
@@ -1094,23 +1105,23 @@ NSUInteger processKeyString(ExtensionString& key)
     const ExtensionString tab       = (ExtensionString() += NSTabCharacter);
     const ExtensionString enter     = (ExtensionString() += NSEnterCharacter);
     
-    appshell_extensions::fixupKey(key, "PageUp", pageUp);
-    appshell_extensions::fixupKey(key, "PageDown", pageDown);
-    appshell_extensions::fixupKey(key, "Home", home);
-    appshell_extensions::fixupKey(key, "End", end);
-    appshell_extensions::fixupKey(key, "Insert", ins);
-    appshell_extensions::fixupKey(key, "Delete", del);
-    appshell_extensions::fixupKey(key, "Backspace", backspace);
-    appshell_extensions::fixupKey(key, "Space", " ");
-    appshell_extensions::fixupKey(key, "Tab", tab);
-    appshell_extensions::fixupKey(key, "Enter", enter);
-    appshell_extensions::fixupKey(key, "Up", "↑");
-    appshell_extensions::fixupKey(key, "Down", "↓");
-    appshell_extensions::fixupKey(key, "Left", "←");
-    appshell_extensions::fixupKey(key, "Right", "→");
+    fixupKey(key, "PageUp", pageUp);
+    fixupKey(key, "PageDown", pageDown);
+    fixupKey(key, "Home", home);
+    fixupKey(key, "End", end);
+    fixupKey(key, "Insert", ins);
+    fixupKey(key, "Delete", del);
+    fixupKey(key, "Backspace", backspace);
+    fixupKey(key, "Space", " ");
+    fixupKey(key, "Tab", tab);
+    fixupKey(key, "Enter", enter);
+    fixupKey(key, "Up", "↑");
+    fixupKey(key, "Down", "↓");
+    fixupKey(key, "Left", "←");
+    fixupKey(key, "Right", "→");
 
     // from unicode display char to ascii hyphen
-    appshell_extensions::fixupKey(key, "−", "-");
+    fixupKey(key, "−", "-");
 
     // Check for F1 - F15 keys.
     if (key.find("F") != ExtensionString::npos) {
@@ -1120,7 +1131,7 @@ NSUInteger processKeyString(ExtensionString& key)
             if (key.find(fKey) != ExtensionString::npos) {
                 unichar ch = i;
                 NSString *actualKey = [NSString stringWithCharacters: &ch length: 1];
-                appshell_extensions::fixupKey(key, fKey, ExtensionString([actualKey UTF8String]));
+                fixupKey(key, fKey, ExtensionString([actualKey UTF8String]));
                 break;
             }
         }

--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -22,8 +22,8 @@
  */
 
 #include "appshell_extensions_platform.h"
-#include "appshell_extensions.h"
 
+#include "client_app.h"
 #include "native_menu_model.h"
 #include "client_handler.h"
 

--- a/appshell/cefclient_mac.mm
+++ b/appshell/cefclient_mac.mm
@@ -16,7 +16,6 @@
 #include "client_handler.h"
 #include "appshell/browser/resource_util.h"
 #include "config.h"
-#include "appshell_extensions.h"
 #include "command_callbacks.h"
 #include "appshell/common/client_switches.h"
 #include "native_menu_model.h"


### PR DESCRIPTION
It was moved to be used by the Windows implementation, but now it is used only by `appshell_extensions_mac.mm` so move there.
While here I cleaned a bit the headers inclusions.
In the cefclient 2623 example code `CreateProcessMessageDelegates` doesn't exists anymore so I want to isolate more `appshell_extensions.h|cpp` code.