### PR TITLE
Init command_line directly in cefclient_<platform>

### DIFF
--- a/appshell/cefclient.cpp
+++ b/appshell/cefclient.cpp
@@ -20,7 +20,6 @@
 #include "config.h"
 
 CefRefPtr<ClientHandler> g_handler;
-CefRefPtr<CefCommandLine> g_command_line;
 
 CefRefPtr<CefBrowser> AppGetBrowser() {
   if (!g_handler.get())
@@ -34,39 +33,24 @@ CefWindowHandle AppGetMainHwnd() {
   return g_handler->GetMainHwnd();
 }
 
-void AppInitCommandLine(int argc, const char* const* argv) {
-  g_command_line = CefCommandLine::CreateCommandLine();
-#if defined(OS_WIN)
-  g_command_line->InitFromString(::GetCommandLineW());
-#else
-  g_command_line->InitFromArgv(argc, argv);
-#endif
-}
-
-// Returns the application command line object.
-CefRefPtr<CefCommandLine> AppGetCommandLine() {
-  return g_command_line;
-}
-
 // Returns the application settings based on command line arguments.
-void AppGetSettings(CefSettings& settings, CefRefPtr<ClientApp> app) {
-  DCHECK(app.get());
-  DCHECK(g_command_line.get());
-  if (!g_command_line.get())
+void AppGetSettings(CefSettings& settings, CefRefPtr<CefCommandLine> command_line) {
+  DCHECK(command_line.get());
+  if (!command_line.get())
     return;
 
 #if defined(OS_WIN)
   settings.multi_threaded_message_loop =
-      g_command_line->HasSwitch(client::switches::kMultiThreadedMessageLoop);
+      command_line->HasSwitch(client::switches::kMultiThreadedMessageLoop);
 #endif
 
   CefString(&settings.cache_path) =
-      g_command_line->GetSwitchValue(client::switches::kCachePath);
+      command_line->GetSwitchValue(client::switches::kCachePath);
   CefString(&settings.log_file) =
-      g_command_line->GetSwitchValue(client::switches::kLogFile);
+      command_line->GetSwitchValue(client::switches::kLogFile);
 
   {
-    std::string str = g_command_line->GetSwitchValue(client::switches::kLogSeverity);
+    std::string str = command_line->GetSwitchValue(client::switches::kLogSeverity);
 
     // Default to LOGSEVERITY_DISABLE
     settings.log_severity = LOGSEVERITY_DISABLE;
@@ -91,7 +75,7 @@ void AppGetSettings(CefSettings& settings, CefRefPtr<ClientApp> app) {
   //CefString(&settings.locale) = appshell::GetCurrentLanguage( );
 
   CefString(&settings.javascript_flags) =
-      g_command_line->GetSwitchValue(client::switches::kJavascriptFlags);
+      command_line->GetSwitchValue(client::switches::kJavascriptFlags);
     
   // Enable dev tools
   settings.remote_debugging_port = REMOTE_DEBUGGING_PORT;

--- a/appshell/cefclient.h
+++ b/appshell/cefclient.h
@@ -26,14 +26,8 @@ std::string AppGetWorkingDirectory();
 // Returns the starting URL
 CefString AppGetInitialURL();
 
-// Initialize the application command line.
-void AppInitCommandLine(int argc, const char* const* argv);
-
-// Returns the application command line object.
-CefRefPtr<CefCommandLine> AppGetCommandLine();
-
 // Returns the application settings based on command line arguments.
-void AppGetSettings(CefSettings& settings, CefRefPtr<ClientApp> app);
+void AppGetSettings(CefSettings& settings, CefRefPtr<CefCommandLine> command_line);
 
 // Returns the application browser settings based on command line arguments.
 void AppGetBrowserSettings(CefBrowserSettings& settings);

--- a/appshell/cefclient_gtk.cc
+++ b/appshell/cefclient_gtk.cc
@@ -153,12 +153,13 @@ int main(int argc, char* argv[]) {
   GtkWidget* window;
 
   // Parse command line arguments.
-  AppInitCommandLine(argc, argv);
+  CefRefPtr<CefCommandLine> cmdLine = CefCommandLine::CreateCommandLine();
+  cmdLine->InitFromArgv(argc, argv);
 
   CefSettings settings;
 
   // Populate the settings based on command line arguments.
-  AppGetSettings(settings, app);
+  AppGetSettings(settings, cmdLine);
 
   settings.no_sandbox = TRUE;
 
@@ -166,9 +167,7 @@ int main(int argc, char* argv[]) {
   if (CefString(&settings.cache_path).length() == 0) {
     CefString(&settings.cache_path) = appshell::AppGetCachePath();
   }
-  
-  CefRefPtr<CefCommandLine> cmdLine = AppGetCommandLine();
-  
+
   if (cmdLine->HasSwitch(client::switches::kStartupPath)) {
     szInitialUrl = cmdLine->GetSwitchValue(client::switches::kStartupPath);
   } else {

--- a/appshell/cefclient_mac.mm
+++ b/appshell/cefclient_mac.mm
@@ -686,8 +686,6 @@ extern NSMutableArray* pendingOpenFiles;
   settings.javascript_access_clipboard = STATE_ENABLED;
   settings.javascript_dom_paste = STATE_ENABLED;
 
-  CefRefPtr<CefCommandLine> cmdLine = AppGetCommandLine();
-
 #ifdef DARK_INITIAL_PAGE
   // Avoid white flash at startup or refresh by making this the default
   // CSS.
@@ -830,12 +828,13 @@ int main(int argc, char* argv[]) {
   [NSApp setDelegate:delegate];
 
   // Parse command line arguments.
-  AppInitCommandLine(argc, argv);
+  CefRefPtr<CefCommandLine> cmdLine = CefCommandLine::CreateCommandLine();
+  cmdLine->InitFromArgv(argc, argv);
 
   CefSettings settings;
 
  // Populate the settings based on command line arguments.
-  AppGetSettings(settings, app);
+  AppGetSettings(settings, cmdLine);
 
   settings.no_sandbox = YES;
     
@@ -851,8 +850,7 @@ int main(int argc, char* argv[]) {
   CGEventRef event = CGEventCreate(NULL);
   CGEventFlags modifiers = CGEventGetFlags(event);
   CFRelease(event);
-  
-  CefRefPtr<CefCommandLine> cmdLine = AppGetCommandLine();
+
   if (cmdLine->HasSwitch(client::switches::kStartupPath)) {
     CefString cmdLineStartupURL = cmdLine->GetSwitchValue(client::switches::kStartupPath);
     std::string startupURLStr(cmdLineStartupURL);


### PR DESCRIPTION
In the cefclient 2623 example code `cefclient.cpp` doesn't exist anymore.
This PR removes `AppInitCommandLine` and `AppGetCommandLine`, instead we call the cef methods directly or pass around the commandLine.

I can pass the commandLine and remove clientApp in `AppGetSettings` because the latter is not used.