### PR TITLE
Support AppGetChromeVersionString and AppGetProductVersionString on Linux

### DIFF
--- a/appshell/appshell_helpers_gtk.cpp
+++ b/appshell/appshell_helpers_gtk.cpp
@@ -25,6 +25,7 @@
 
 #include "appshell/browser/resource.h"
 #include "appshell/common/client_switches.h"
+#include "appshell/version_linux.h"
 #include "include/cef_base.h"
 #include "include/cef_version.h"
 
@@ -114,13 +115,18 @@ CefString AppGetCachePath() {
 }
 
 CefString AppGetProductVersionString() {
-    // TODO
-    return CefString("");
+    std::string s = APP_NAME "/" APP_VERSION;
+    CefString ret;
+    ret.FromString(s);
+    return ret;
 }
 
 CefString AppGetChromiumVersionString() {
-    // TODO
-    return CefString("");
+    std::wostringstream versionStream(L"");
+    versionStream << L"Chrome/" << cef_version_info(2) << L"." << cef_version_info(3)
+                  << L"." << cef_version_info(4) << L"." << cef_version_info(5);
+
+    return CefString(versionStream.str());
 }
 
 char* AppInitWorkingDirectory() {

--- a/appshell/version_linux.h
+++ b/appshell/version_linux.h
@@ -1,0 +1,1 @@
+#define APP_VERSION "1.9.0.0"

--- a/tasks/set-release.js
+++ b/tasks/set-release.js
@@ -49,6 +49,7 @@ module.exports = function (grunt) {
             buildInstallerScriptPath    = "installer/mac/buildInstaller.sh",
             versionRcPath               = "appshell/version.rc",
             infoPlistPath               = "appshell/mac/Info.plist",
+            linuxVersionFile            = "appshell/version_linux.h",
             release                     = grunt.option("release") || "",
             text,
             newVersion;
@@ -113,5 +114,14 @@ module.exports = function (grunt) {
             "$1" + newVersion.version + "$3"
         );
         grunt.file.write(infoPlistPath, text);
+
+        // 6. Open appshell/version_linux.h and change `APP_VERSION`
+        text = grunt.file.read(linuxVersionFile);
+        text = safeReplace(
+            text,
+            /APP_VERSION "(\d+\.\d+\.\d+\.\d+)"/,
+            'APP_VERSION "' + newVersion.major + "." + newVersion.minor + "." + newVersion.patch + "." + (newVersion.build.length ? newVersion.build : "0") + '"'
+        );
+        grunt.file.write(linuxVersionFile, text);
     });
 };


### PR DESCRIPTION
This is the updated version of https://github.com/adobe/brackets-shell/pull/511 
Rebasing that was a bit of a pain so I created it anew.
