### PR TITLE
Always use node.exe 32 bit

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -82,9 +82,7 @@ module.exports = function (grunt) {
             },
             "node-win": {
                 "dest"      : "<%= downloads %>",
-                "src"       : process.arch === "x64" ?
-                                "http://nodejs.org/dist/v<%= node.version %>/win-x64/node.exe" :
-                                "http://nodejs.org/dist/v<%= node.version %>/win-x86/node.exe"
+                "src"       : "http://nodejs.org/dist/v<%= node.version %>/win-x86/node.exe"
             }
         },
         "clean": {


### PR DESCRIPTION
If automation use x64 Windows platform to generate the installer, we could end up distributing the x64 bit version of node.exe to 32bit Windows users, which could lead to problems.
And I think it happened...
Since it is fine to use the 32 bit version of node.exe on 64bit Windows, use it unconditionally.