### PR TITLE
Fixed #13040 - Limited the size of cache to 250 MB in order to bloating of live-dev-profile folder in APPDATA

### DIFF
--- a/appshell/appshell_extensions_gtk.cpp
+++ b/appshell/appshell_extensions_gtk.cpp
@@ -64,7 +64,7 @@ int GErrorToErrorCode(GError *gerror) {
 
 int32 OpenLiveBrowser(ExtensionString argURL, bool enableRemoteDebugging)
 {
-    const char *remoteDebuggingFormat = "--no-first-run --no-default-browser-check --disable-default-apps --allow-file-access-from-files --temp-profile --user-data-dir=%s --remote-debugging-port=9222";
+    const char *remoteDebuggingFormat = "--no-first-run --no-default-browser-check --disable-default-apps --allow-file-access-from-files --temp-profile --user-data-dir=%s --disk-cache-size=250000000 --remote-debugging-port=9222";
     gchar *remoteDebugging;
     gchar *cmdline;
     int error = ERR_BROWSER_NOT_INSTALLED;

--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -263,6 +263,7 @@ int32 OpenLiveBrowser(ExtensionString argURL, bool enableRemoteDebugging)
                       @"--disable-default-apps",
                       debugPortCommandlineArguments,
                       debugProfilePath,
+                      @"--disk-cache-size=250000000",
                       urlString,
                       nil];
 

--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -342,7 +342,7 @@ int32 OpenLiveBrowser(ExtensionString argURL, bool enableRemoteDebugging)
         profilePath += L"\\live-dev-profile";
         args += L" --user-data-dir=\"";
         args += profilePath;
-        args += L"\" --no-first-run --no-default-browser-check --disable-default-apps --allow-file-access-from-files --remote-debugging-port=9222 ";
+        args += L"\" --disk-cache-size=250000000 --no-first-run --no-default-browser-check --disable-default-apps --allow-file-access-from-files --remote-debugging-port=9222 ";
     } else {
         args += L" ";
     }


### PR DESCRIPTION
Added a command line flag to the cef to limit cache size to 250 MB while launching Live Preview