### PR TITLE
Fixed #11281 Added a registry entry for context menu entry to open current folder as brackets project

### DIFF
--- a/installer/win/Brackets.wxs
+++ b/installer/win/Brackets.wxs
@@ -98,6 +98,15 @@
             <RegistryValue Root="HKCR" Key="directory\shell\!(loc.ProductName)\command" Value="[INSTALLDIR]$(var.ExeName).exe &quot;%1&quot;"
                                Type="string" />
 
+            <RegistryValue Root="HKCR" Key="directory\background\shell\!(loc.ProductName)" Value="!(loc.ExplorerDirectoryOpenContextMenu)"
+                               Type="string" />
+
+            <RegistryValue Root="HKCR" Key="directory\background\shell\!(loc.ProductName)" Name="Icon" Value="[INSTALLDIR]$(var.ExeName).exe"
+                               Type="string" />
+
+            <RegistryValue Root="HKCR" Key="directory\background\shell\!(loc.ProductName)\command" Value="[INSTALLDIR]$(var.ExeName).exe &quot;%V&quot;"
+                               Type="string" />
+
         </Component>
         
         <!-- Start Menu Shortcuts-->


### PR DESCRIPTION
This is fix for https://github.com/adobe/brackets/issues/11281
I am not able to test my changes as I am unable to build msi installer in my local.