### PR TITLE
Add iphlpapi to Windows linker libs

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -3592,6 +3592,7 @@
               'winmm.lib',
               'shlwapi.lib',
               'advapi32.lib',
+              'iphlpapi.lib',
             ],
 
             'conditions': [


### PR DESCRIPTION
This was needed for me to get the latest master to compile using Visual Studio 2015. Maybe you've added the library to the linker manually in VS, @nethip?

This won't fix the issue I've had with VS 2012, mentioned in https://github.com/adobe/brackets-shell/pull/603#issuecomment-308977273. I've now uninstalled VS 2012 and switched over to VS 2015 😄 