### PR TITLE
Adding a check for node version during the build. 

### DIFF
--- a/tasks/setup.js
+++ b/tasks/setup.js
@@ -455,6 +455,33 @@ module.exports = function (grunt) {
         }
     });
 
+    grunt.registerTask("node-check", function() {
+        var done = this.async(),
+            promise,
+            systemNodeCheck,
+            bundledNodeCheck,
+            bundledNodeVersion,
+            systemNodeVersion;
+
+        var bundledNodeLocation = path.join("deps", "node", "node.exe");
+
+        bundledNodeCheck = exec(bundledNodeLocation + " -v");
+
+        bundledNodeCheck.then(function (bundleNodeCmdStdout) {
+            bundledNodeVersion = bundleNodeCmdStdout[0];
+        }).then(function() {
+            systemNodeCheck = exec("node -v");
+            return systemNodeCheck;
+        })
+        .then(function(systemNodeCmdStdout) {
+            systemNodeVersion = systemNodeCmdStdout[0];
+            return systemNodeVersion === bundledNodeVersion ? done() : done(false);
+        }, function (err) {
+            grunt.log.error(err);
+            done(false);
+        });
+    });
+
     function nodeWriteVersion() {
         // write empty file with node-version name
         grunt.file.write("deps/node/version-" + grunt.config("node.version") + ".txt", "");
@@ -556,5 +583,5 @@ module.exports = function (grunt) {
     });
 
     // task: setup
-    grunt.registerTask("setup", ["cef", "node", "icu", "create-project"]);
+    grunt.registerTask("setup", ["cef", "node", "node-check", "icu", "create-project"]);
 };

--- a/tasks/setup.js
+++ b/tasks/setup.js
@@ -460,10 +460,17 @@ module.exports = function (grunt) {
             promise,
             systemNodeCheck,
             bundledNodeCheck,
+            bundledNodeLocation,
             bundledNodeVersion,
             systemNodeVersion;
 
-        var bundledNodeLocation = path.join("deps", "node", "node.exe");
+        if (platform === "win") {
+            bundledNodeLocation = path.join("deps", "node", "node.exe");
+        }
+        else {
+            bundledNodeLocation = path.join("deps", "node", "bin", "Brackets-node");
+        }
+        
 
         bundledNodeCheck = exec(bundledNodeLocation + " -v");
 


### PR DESCRIPTION
Adding a check for node version during the build. The setup task should fail if node version being bundled differs from the node version on the machine