### PR TITLE
[Linux only] CEF Upgrade to 2785

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,7 +38,7 @@ module.exports = function (grunt) {
     }
 
     if (platform === "linux") {
-        cef_version = "3.2785.1485";
+        cef_version = "3.2785.1486";
     }
 
     grunt.initConfig({

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,7 +38,7 @@ module.exports = function (grunt) {
     }
 
     if (platform === "linux") {
-        cef_version = "3.2704.1414";
+        cef_version = "3.2785.1485";
     }
 
     grunt.initConfig({

--- a/appshell/appshell_extensions.js
+++ b/appshell/appshell_extensions.js
@@ -942,5 +942,8 @@ if (!appshell.app) {
 
  
     // Alias the appshell object to brackets. This is temporary and should be removed.
-    brackets = appshell;
+    // The following is now moved to Global.js as newer versions of CEF crash upon
+    // eval of this statement.
+    //brackets = appshell;
+    
 })();

--- a/appshell/cefclient_gtk.cc
+++ b/appshell/cefclient_gtk.cc
@@ -31,7 +31,6 @@
 static std::string APPICONS[] = {"appshell32.png","appshell48.png","appshell128.png","appshell256.png"};
 int add_handler_id;
 bool isReallyClosing = false;
-char *DEVICE_SCALE_COMMAND_LINE_OPTION = "--force-device-scale-factor=1";
 
 // The global ClientHandler reference.
 extern CefRefPtr<ClientHandler> g_handler;

--- a/appshell/cefclient_gtk.cc
+++ b/appshell/cefclient_gtk.cc
@@ -112,10 +112,8 @@ void TerminationSignalHandler(int signatl) {
 }
 
 int RunMain(int argc, char* argv[]) {
-
   // Create a copy of |argv| on Linux because Chromium mangles the value
   // internally (see issue #620).
-
   CefScopedArgArray scoped_arg_array(argc, argv);
   char** argv_copy = scoped_arg_array.array();
 

--- a/appshell/cefclient_gtk.cc
+++ b/appshell/cefclient_gtk.cc
@@ -111,7 +111,7 @@ void TerminationSignalHandler(int signatl) {
   MainContext::Get()->GetRootWindowManager()->CloseAllWindows(true);
 }
 
-int RunMain(int argc, char** argv) {
+int RunMain(int argc, char* argv[]) {
 
   // Create a copy of |argv| on Linux because Chromium mangles the value
   // internally (see issue #620).

--- a/appshell/cefclient_gtk.cc
+++ b/appshell/cefclient_gtk.cc
@@ -112,62 +112,7 @@ void TerminationSignalHandler(int signatl) {
   MainContext::Get()->GetRootWindowManager()->CloseAllWindows(true);
 }
 
-int RunMain(int _argc, char** _argv) {
-
-  // We are going to create a copy of the args and add
-  // another command line parameter to disable hi-dpi on Linux
-  // as it is breaking the layout upon launching. Tried supplying
-  // the argument via OnBeforeChildProcessLaunch and OnBeforeCommandLineProcessing
-  // and nothing seemed to have worked. So going the hard way replicating
-  // parameters and adding the extra parameter to the list.
-
-  // Note: This piece of code is temporary and should go away
-  // once we start supporting hi-dpi on Linux.
-
-  char** argv = (char **) malloc((_argc+2) * sizeof (char **));
-
-  int    argc      = _argc + 1,
-         iArgument = 0;
-
-  bool arg_found = false;
-  for(; iArgument < _argc; ++iArgument)
-  {
-      // check if the command line option is already passed
-      // on by the user.
-      char *pch = strstr (DEVICE_SCALE_COMMAND_LINE_OPTION, _argv[iArgument]);
-      if (pch) {
-        arg_found = true;
-        break;
-      }
-
-      size_t cmLineArgLen     = strlen(_argv[iArgument])+1;
-      argv[iArgument] = (char *)malloc(cmLineArgLen);
-      memcpy(argv[iArgument], _argv[iArgument], cmLineArgLen);
-  }
-
-  // Add force-device-scale-factor to the copy.
-  if (!arg_found) {
-
-    size_t cmLineArgLen = strlen(DEVICE_SCALE_COMMAND_LINE_OPTION)+1;
-    argv[iArgument] = (char *)malloc(cmLineArgLen);
-    memcpy(argv[iArgument], DEVICE_SCALE_COMMAND_LINE_OPTION, cmLineArgLen);
-
-    argv[argc] = NULL;
-
-  } else {
-
-    // User had already passed this option, so honor that.
-    // Free memory of allocated memory.
-    for(int i = 0; i < argc; ++i)
-    {
-        free(argv[i]);
-    }
-    free(argv);
-
-    //Just use the passed parameters.
-    argc = _argc;
-    argv = _argv;
-  }
+int RunMain(int argc, char** argv) {
 
   // Create a copy of |argv| on Linux because Chromium mangles the value
   // internally (see issue #620).

--- a/appshell/client_handler.cpp
+++ b/appshell/client_handler.cpp
@@ -202,7 +202,11 @@ bool ClientHandler::OnDragEnter(CefRefPtr<CefBrowser> browser,
 }
 
 void ClientHandler::OnLoadStart(CefRefPtr<CefBrowser> browser,
-                                CefRefPtr<CefFrame> frame) {
+                                CefRefPtr<CefFrame> frame
+                                #ifdef OS_LINUX
+                                  ,TransitionType transition_type
+                                #endif
+                                ) {
   CEF_REQUIRE_UI_THREAD();
 
   if (m_BrowserId == browser->GetIdentifier() && frame->IsMain()) {

--- a/appshell/client_handler.h
+++ b/appshell/client_handler.h
@@ -126,7 +126,11 @@ virtual bool OnBeforePopup(CefRefPtr<CefBrowser> browser,
 
   // CefLoadHandler methods
   virtual void OnLoadStart(CefRefPtr<CefBrowser> browser,
-                           CefRefPtr<CefFrame> frame) OVERRIDE;
+                           CefRefPtr<CefFrame> frame
+                    #ifdef OS_LINUX
+                           ,TransitionType transition_type
+                    #endif
+                           ) OVERRIDE;
   virtual void OnLoadEnd(CefRefPtr<CefBrowser> browser,
                          CefRefPtr<CefFrame> frame,
                          int httpStatusCode) OVERRIDE;


### PR DESCRIPTION
CEF needs to be upgraded to a later version, as the current version of CEF has some issues with menus text getting corrupt. Also CEF needs to be patched wit IME as IME handling is missing in CEF. 

The following are the note worthy things.

1) Upgraded to CEF 2785
2) Moved the initialization of brackets object to `Global.js`
3) ~~Forced the DPI scale factor to 1, as rendering is breaking upon launching. Surprisingly, upon resizing,  the view starts to render properly. We  need to revisit this in the next sprint.~~(This is not required anymore, as the rendering issue is now fixed with a different technique with a fake resize)