### PR TITLE
Restoring the brackets alias intitialization in appshell_extensions.js

### DIFF
--- a/appshell/appshell_extensions.js
+++ b/appshell/appshell_extensions.js
@@ -27,7 +27,7 @@
 // Note: All file native file i/o functions are synchronous, but are exposed
 // here as asynchronous calls. 
 
-var appshell;
+var appshell, brackets;
 if (!appshell) {
     appshell = {};
 }
@@ -36,6 +36,9 @@ if (!appshell.fs) {
 }
 if (!appshell.app) {
     appshell.app = {};
+}
+if (!brackets) {
+    brackets = appshell;
 }
 (function () {
     // Error values. These MUST be in sync with the error values
@@ -941,6 +944,3 @@ if (!appshell.app) {
      };
     
 })();
-
-// Alias the appshell object to brackets. This is temporary and should be removed.
-var brackets = appshell;

--- a/appshell/appshell_extensions.js
+++ b/appshell/appshell_extensions.js
@@ -37,6 +37,8 @@ if (!appshell.fs) {
 if (!appshell.app) {
     appshell.app = {};
 }
+
+// Alias the appshell object to brackets. This is temporary and should be removed.
 if (!brackets) {
     brackets = appshell;
 }

--- a/appshell/appshell_extensions.js
+++ b/appshell/appshell_extensions.js
@@ -939,11 +939,8 @@ if (!appshell.app) {
      appshell.app.getMachineHash = function (callback) {
          GetMachineHash(callback || _dummyCallback);
      };
-
- 
-    // Alias the appshell object to brackets. This is temporary and should be removed.
-    // The following is now moved to Global.js as newer versions of CEF crash upon
-    // eval of this statement.
-    //brackets = appshell;
     
 })();
+
+// Alias the appshell object to brackets. This is temporary and should be removed.
+var brackets = appshell;


### PR DESCRIPTION
This is still going to be required as brackets.app.language was getting accessed even before it was getting initialized in global.js. 

I have unit tested on Win, Linux and MAC with this change and the change seems to be working fine. Also I tested by hard routing the language to "fr", and Brackets is now correctly able to take the language, defined by `brackets.app.language`.

Thanks @swmitra for debugging this. Could you please review this?
@abhijitapte It would be great if you can review this as well.