### PR TITLE
Linux native menus checked entries

### DIFF
--- a/appshell/appshell_extensions_gtk.cpp
+++ b/appshell/appshell_extensions_gtk.cpp
@@ -95,6 +95,8 @@
 
 typedef char s8;
 
+bool StMenuCommandSkipper::sSkipMenuCommand = false;
+
 extern CefRefPtr<ClientHandler> g_handler;
 
 // Supported browsers (order matters):
@@ -1109,7 +1111,6 @@ int _getMenuItemPosition(GtkWidget* parent, GtkWidget* menuItem)
         }
         index++;
     } while ((children = g_list_next(children)) != NULL);
-    g_list_free(children);
 
     return -1;
 }

--- a/appshell/appshell_extensions_gtk.cpp
+++ b/appshell/appshell_extensions_gtk.cpp
@@ -1098,8 +1098,12 @@ int32 GetMenuItemState(CefRefPtr<CefBrowser> browser, ExtensionString commandId,
     return NO_ERROR;
 }
 
-void CheckedItemCallbach(GtkWidget* checkMenuItem, GtkWidget* originalMenuItem) {
-    gtk_menu_item_activate(GTK_MENU_ITEM(originalMenuItem));
+void CheckedItemCallback(GtkWidget* checkMenuItem, GtkWidget* originalMenuItem) {
+    if (gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(checkMenuItem))) {
+        gtk_menu_item_activate(GTK_MENU_ITEM(originalMenuItem));
+    } else {
+        gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(checkMenuItem), true);
+    }
 }
 
 int32 SetMenuItemState(CefRefPtr<CefBrowser> browser, ExtensionString command, bool& enabled, bool& checked)
@@ -1140,7 +1144,7 @@ int32 SetMenuItemState(CefRefPtr<CefBrowser> browser, ExtensionString command, b
         checkedMenuItem = gtk_check_menu_item_new_with_label(label);
         gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(checkedMenuItem), true);
         gtk_widget_set_sensitive(checkedMenuItem, enabled);
-        g_signal_connect(checkedMenuItem, "activate", G_CALLBACK(CheckedItemCallbach), menuItem);
+        g_signal_connect(checkedMenuItem, "activate", G_CALLBACK(CheckedItemCallback), menuItem);
         gtk_menu_shell_insert(GTK_MENU_SHELL(parent), checkedMenuItem, checkedItemPos);
         gtk_widget_show(checkedMenuItem);
         gtk_widget_hide(menuItem);

--- a/appshell/appshell_extensions_gtk.cpp
+++ b/appshell/appshell_extensions_gtk.cpp
@@ -1141,17 +1141,19 @@ int32 SetMenuItemState(CefRefPtr<CefBrowser> browser, ExtensionString command, b
     }
 
     if (checked == true) {
-        checkedMenuItem = gtk_check_menu_item_new_with_label(label);
-        gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(checkedMenuItem), true);
+        if (GTK_IS_CHECK_MENU_ITEM(checkedMenuItem)) {
+            checkedMenuItem = gtk_check_menu_item_new_with_label(label);
+            gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(checkedMenuItem), true);
+            g_signal_connect(checkedMenuItem, "activate", G_CALLBACK(CheckedItemCallback), menuItem);
+            gtk_menu_shell_insert(GTK_MENU_SHELL(parent), checkedMenuItem, checkedItemPos);
+        }
         gtk_widget_set_sensitive(checkedMenuItem, enabled);
-        g_signal_connect(checkedMenuItem, "activate", G_CALLBACK(CheckedItemCallback), menuItem);
-        gtk_menu_shell_insert(GTK_MENU_SHELL(parent), checkedMenuItem, checkedItemPos);
         gtk_widget_show(checkedMenuItem);
         gtk_widget_hide(menuItem);
     } else {
         gtk_widget_show(menuItem);
         if (GTK_IS_CHECK_MENU_ITEM(checkedMenuItem)) {
-            gtk_widget_destroy(checkedMenuItem);
+            gtk_widget_hide(checkedMenuItem);
         }
     }
     return NO_ERROR;

--- a/appshell/appshell_extensions_gtk.cpp
+++ b/appshell/appshell_extensions_gtk.cpp
@@ -1122,9 +1122,6 @@ int32 SetMenuItemState(CefRefPtr<CefBrowser> browser, ExtensionString command, b
         return ERR_NOT_FOUND;
     }
     GtkWidget* menuItem = (GtkWidget*) model.getOsItem(tag);
-    gtk_widget_set_sensitive(menuItem, enabled);
-
-    // Functionality for checked
     GtkWidget* parent = gtk_widget_get_parent(menuItem);
     int position = _getMenuItemPosition(parent, menuItem);
     const gchar* label = gtk_menu_item_get_label(GTK_MENU_ITEM(menuItem));
@@ -1136,7 +1133,6 @@ int32 SetMenuItemState(CefRefPtr<CefBrowser> browser, ExtensionString command, b
     } else if (checked == false){
         newMenuItem = gtk_menu_item_new_with_label(label);
     }
-
     gtk_widget_destroy(menuItem);
 
     InstallMenuHandler(newMenuItem, browser, tag);

--- a/appshell/appshell_extensions_gtk.cpp
+++ b/appshell/appshell_extensions_gtk.cpp
@@ -1113,37 +1113,42 @@ int32 SetMenuItemState(CefRefPtr<CefBrowser> browser, ExtensionString command, b
     gtk_widget_set_sensitive(menuItem, enabled);
 
     // Functionality for checked
-    gint position;
+    gint checkedItemPos = -1;
     GtkWidget* checkedMenuItem;
     GtkWidget* parent = gtk_widget_get_parent(menuItem);
+    const gchar* label = gtk_menu_item_get_label(GTK_MENU_ITEM(menuItem));
 
     if (GTK_IS_CONTAINER(parent)) {
         GList* children = gtk_container_get_children(GTK_CONTAINER(parent));
         gint index = 0;
         do {
             GtkWidget* widget = (GtkWidget*) children->data;
-            if (widget == menuItem)
-                position = index + 1;
-            if (index == position && GTK_IS_CHECK_MENU_ITEM(widget))
+            const gchar* widgetLabel = gtk_menu_item_get_label(GTK_MENU_ITEM(widget));
+            if (widget == menuItem) {
+                checkedItemPos = index + 1;
+            }
+            if (index >= checkedItemPos && GTK_IS_CHECK_MENU_ITEM(widget) && strcmp(widgetLabel, label) == 0) {
                 checkedMenuItem = widget;
+                break;
+            }
             index++;
         } while ((children = g_list_next(children)) != NULL);
         g_list_free(children);
     }
 
     if (checked == true) {
-        const gchar* label = gtk_menu_item_get_label(GTK_MENU_ITEM(menuItem));
         checkedMenuItem = gtk_check_menu_item_new_with_label(label);
         gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(checkedMenuItem), true);
         gtk_widget_set_sensitive(checkedMenuItem, enabled);
         g_signal_connect(checkedMenuItem, "activate", G_CALLBACK(CheckedItemCallbach), menuItem);
-        gtk_menu_shell_insert(GTK_MENU_SHELL(parent), checkedMenuItem, position);
+        gtk_menu_shell_insert(GTK_MENU_SHELL(parent), checkedMenuItem, checkedItemPos);
         gtk_widget_show(checkedMenuItem);
         gtk_widget_hide(menuItem);
     } else {
         gtk_widget_show(menuItem);
-        if (GTK_IS_WIDGET(checkedMenuItem))
+        if (GTK_IS_CHECK_MENU_ITEM(checkedMenuItem)) {
             gtk_widget_destroy(checkedMenuItem);
+        }
     }
     return NO_ERROR;
 }

--- a/appshell/appshell_extensions_gtk.cpp
+++ b/appshell/appshell_extensions_gtk.cpp
@@ -1123,8 +1123,17 @@ int32 SetMenuItemState(CefRefPtr<CefBrowser> browser, ExtensionString command, b
         return ERR_NOT_FOUND;
     }
     GtkWidget* menuItem = (GtkWidget*) model.getOsItem(tag);
+    if (menuItem == NULL) {
+        return ERR_UNKNOWN;
+    }
     GtkWidget* parent = gtk_widget_get_parent(menuItem);
+    if (parent == NULL) {
+        return ERR_UNKNOWN;
+    }
     int position = _getMenuItemPosition(parent, menuItem);
+    if (position < 0) {
+        return ERR_UNKNOWN;
+    }
     const gchar* label = gtk_menu_item_get_label(GTK_MENU_ITEM(menuItem));
 
     GtkWidget* newMenuItem;

--- a/appshell/appshell_extensions_gtk.cpp
+++ b/appshell/appshell_extensions_gtk.cpp
@@ -1098,6 +1098,10 @@ int32 GetMenuItemState(CefRefPtr<CefBrowser> browser, ExtensionString commandId,
     return NO_ERROR;
 }
 
+void CheckedItemCallbach(GtkWidget* checkMenuItem, GtkWidget* originalMenuItem) {
+    gtk_menu_item_activate(GTK_MENU_ITEM(originalMenuItem));
+}
+
 int32 SetMenuItemState(CefRefPtr<CefBrowser> browser, ExtensionString command, bool& enabled, bool& checked)
 {
     NativeMenuModel& model = NativeMenuModel::getInstance(getMenuParent(browser));

--- a/appshell/appshell_extensions_gtk.cpp
+++ b/appshell/appshell_extensions_gtk.cpp
@@ -1141,7 +1141,7 @@ int32 SetMenuItemState(CefRefPtr<CefBrowser> browser, ExtensionString command, b
     }
 
     if (checked == true) {
-        if (GTK_IS_CHECK_MENU_ITEM(checkedMenuItem)) {
+        if (!GTK_IS_CHECK_MENU_ITEM(checkedMenuItem)) {
             checkedMenuItem = gtk_check_menu_item_new_with_label(label);
             gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(checkedMenuItem), true);
             g_signal_connect(checkedMenuItem, "activate", G_CALLBACK(CheckedItemCallback), menuItem);

--- a/appshell/appshell_extensions_platform.h
+++ b/appshell/appshell_extensions_platform.h
@@ -108,6 +108,20 @@ public:
     void operator()(std::string &contents);
 };
 
+#if defined(OS_LINUX)
+class StMenuCommandSkipper {
+public:
+
+    StMenuCommandSkipper()  { sSkipMenuCommand = true; }
+    ~StMenuCommandSkipper() { sSkipMenuCommand = false;}
+
+    static bool GetMenuCmdSkipFlag () { return sSkipMenuCommand;}
+
+private:
+    static bool sSkipMenuCommand;
+};
+#endif
+
 #if defined(OS_MACOSX) || defined(OS_LINUX)
 void DecodeContents(std::string &contents, const std::string& encoding);
 #endif

--- a/appshell/browser/root_window_gtk.cc
+++ b/appshell/browser/root_window_gtk.cc
@@ -601,13 +601,49 @@ void RootWindowGtk::MenubarSizeAllocated(GtkWidget* widget,
   self->menubar_height_ = allocation->height;
 }
 
+// Brackets specific change.
+// GTK is toggling the menu state just by
+// clicking on the menu entry. So posting a task to undo that
+// unwanted side effect. This is a @nethip hack.
+void DelayedMenuMarkToggle(GtkWidget *menuItem){
+
+  if (GTK_IS_CHECK_MENU_ITEM(menuItem)) {
+    // It is important to make sure our MenuItemACtivated
+    // knows that we are only changing the state and not
+    // firing any command as such.
+    StMenuCommandSkipper skipCmd;
+
+    // Get the current state of the menu.
+    gboolean menuState = gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(menuItem));
+
+    // Now go about toggling the state. If Brackets is triggering a menu state change,
+    // that will get executed later than DelayedMenuMarkToggle, as this task would have been
+    // posted prior to shell call to fire a command, so need not worry about this function
+    // getting executed after the shell call.
+    gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(menuItem), !menuState);
+  }
+}
+
 // static
 gboolean RootWindowGtk::MenuItemActivated(GtkWidget* widget,
                                           RootWindowGtk* self) {
-  // Retrieve the menu ID set in AddMenuEntry.
-  int tag = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(widget), kMenuIdKey));
-  if (self && self->browser_window_)
-    self->browser_window_->DispatchCommandToBrowser(self->GetBrowser(), tag);
+  // Since we have migrated to checked menu items, setting the
+  // state of the menu is triggering a menu activation. So made
+  // sure we actually execute a command only when is menu is
+  // actually activated by the user and not when setting the menu
+  // state.
+  if(!StMenuCommandSkipper::GetMenuCmdSkipFlag()){
+
+    // Post a message to undo the undesired menu state change.
+    // See the comments above for explanation.
+    CefPostTask(TID_UI, base::Bind(&DelayedMenuMarkToggle, widget));
+
+    // Retrieve the menu ID set in AddMenuEntry.
+    int tag = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(widget), kMenuIdKey));
+    if (self && self->browser_window_)
+      self->browser_window_->DispatchCommandToBrowser(self->GetBrowser(), tag);
+    }
+
 }
 
 // static


### PR DESCRIPTION
This PR adds functionality so that entries in the native Linux menus reflect their checked / unchecked status.