### PR TITLE
Linux window size and position 

### DIFF
--- a/appshell/browser/root_window_gtk.cc
+++ b/appshell/browser/root_window_gtk.cc
@@ -78,6 +78,13 @@ void SaveWindowState(GtkWindow* window) {
   gint width  = DEFAULT_WINDOW_WIDTH;
   gint height = DEFAULT_WINDOW_HEIGHT;
 
+  // Try to center the window.
+  GdkScreen* screen = gdk_screen_get_default();
+  if (screen) {
+    left = (gdk_screen_get_width(screen)  - DEFAULT_WINDOW_WIDTH) / 2 ;
+    top  = (gdk_screen_get_height(screen) - DEFAULT_WINDOW_HEIGHT) / 2 ;
+  }
+
   GKeyFile* key_file = g_key_file_new();
   GError* err = NULL;
   gchar* filePath = NULL;
@@ -182,16 +189,15 @@ void LoadWindowState(GtkWindow* window) {
       height    = DEFAULT_WINDOW_HEIGHT;
       maximized = TRUE;
     }
-
-    gtk_window_move(GTK_WINDOW(window), left, top);
-    gtk_window_set_default_size(GTK_WINDOW(window), width, height);
-
-    if (maximized)
-      MaximizeWindow(window);
-
   } else {
     any_error = true;
   }
+
+  gtk_window_move(GTK_WINDOW(window), left, top);
+  gtk_window_set_default_size(GTK_WINDOW(window), width, height);
+
+  if (maximized)
+    MaximizeWindow(window);
 
   if (err || any_error) {
 

--- a/appshell/browser/root_window_gtk.cc
+++ b/appshell/browser/root_window_gtk.cc
@@ -71,14 +71,14 @@ void SaveWindowState(GtkWindow* window) {
       top = g_key_file_get_integer(key_file, "position", "top", &error);
       width = g_key_file_get_integer(key_file, "size", "width", &error);
       height = g_key_file_get_integer(key_file, "size", "height", &error);
-      // If any value can not be readed, save defaults
+      // If any value can not be readed, restore defaults
       if (left == 0 || top == 0 || width == 0 || height == 0) {
         left = 1;
         top = 1;
         width = 800;
         height = 600;
       }
-    // If we can not load the file, save defaults
+    // If we can not load the file, set defaults
     } else {
       left = 1;
       top = 1;
@@ -100,6 +100,7 @@ void SaveWindowState(GtkWindow* window) {
 }
 
 void LoadWindowState(GtkWindow* window) {
+  // Default values if It is not possible to load the key file
   gint left = 1;
   gint top = 1;
   gint width = 800;
@@ -117,7 +118,7 @@ void LoadWindowState(GtkWindow* window) {
     width = g_key_file_get_integer(key_file, "size", "width", &error);
     height = g_key_file_get_integer(key_file, "size", "height", &error);
     maximized = g_key_file_get_boolean(key_file, "state", "maximized", &error);
-    // If any value can not be readed, load defaults
+    // If any value can not be readed, set defaults again
     if (left == 0 || top == 0 || width == 0 || height == 0) {
       left = 1;
       top = 1;


### PR DESCRIPTION
In the different Linux versions (Debian 8 and 9, Ubuntu 16) in which I have tested Brackets compiled from the Master branch with the latest commits (same result in the lastest release), this still does not remember the position and size of the window from one execution to another (issues #13182 and #7174).

I have fixed this using a "key file" that is created automatically by Brackets, updated every time the application is closed and read every time it starts.

Maybe it's not the best solution, but I've been using it for a few days and it works well. So I leave this PR for your consideration.

Thank you.

Edited: tested in the three distributions mentioned above. 