### PR TITLE
Linux native menus lost shortcuts

### DIFF
--- a/appshell/appshell_extensions_gtk.cpp
+++ b/appshell/appshell_extensions_gtk.cpp
@@ -1064,6 +1064,7 @@ int32 AddMenuItem(CefRefPtr<CefBrowser> browser, ExtensionString parentCommand, 
 
     ExtensionString commandId = model.getCommandId(tag);
     model.setOsItem(tag, entry);
+	model.setKey(tag, key);
     ParseShortcut(browser, entry, key, commandId);
     GtkWidget* menuHeader = (GtkWidget*) model.getOsItem(parentTag);
     GtkWidget* menuWidget = gtk_menu_item_get_submenu(GTK_MENU_ITEM(menuHeader));
@@ -1147,6 +1148,9 @@ int32 SetMenuItemState(CefRefPtr<CefBrowser> browser, ExtensionString command, b
 
     InstallMenuHandler(newMenuItem, browser, tag);
     model.setOsItem(tag, newMenuItem);
+	ExtensionString key = model.getKey(tag);
+	ExtensionString commandId = model.getCommandId(tag);
+	ParseShortcut(browser, newMenuItem, key, commandId);
     gtk_menu_shell_insert(GTK_MENU_SHELL(parent), newMenuItem, position);
     gtk_widget_set_sensitive(newMenuItem, enabled);
     gtk_widget_show(newMenuItem);
@@ -1396,5 +1400,3 @@ std::string GetSystemUniqueID()
 
     return buf;
 }
-
-

--- a/appshell/appshell_extensions_gtk.cpp
+++ b/appshell/appshell_extensions_gtk.cpp
@@ -1064,7 +1064,7 @@ int32 AddMenuItem(CefRefPtr<CefBrowser> browser, ExtensionString parentCommand, 
 
     ExtensionString commandId = model.getCommandId(tag);
     model.setOsItem(tag, entry);
-	model.setKey(tag, key);
+    model.setKey(tag, key);
     ParseShortcut(browser, entry, key, commandId);
     GtkWidget* menuHeader = (GtkWidget*) model.getOsItem(parentTag);
     GtkWidget* menuWidget = gtk_menu_item_get_submenu(GTK_MENU_ITEM(menuHeader));
@@ -1150,7 +1150,7 @@ int32 SetMenuItemState(CefRefPtr<CefBrowser> browser, ExtensionString command, b
 
     model.setOsItem(tag, newMenuItem);
     ExtensionString key = model.getKey(tag);
-	ParseShortcut(browser, newMenuItem, key, command);
+    ParseShortcut(browser, newMenuItem, key, command);
     gtk_menu_shell_insert(GTK_MENU_SHELL(parent), newMenuItem, position);
     gtk_widget_set_sensitive(newMenuItem, enabled);
     gtk_widget_show(newMenuItem);

--- a/appshell/appshell_extensions_gtk.cpp
+++ b/appshell/appshell_extensions_gtk.cpp
@@ -1141,16 +1141,16 @@ int32 SetMenuItemState(CefRefPtr<CefBrowser> browser, ExtensionString command, b
     if (checked == true) {
         newMenuItem = gtk_check_menu_item_new_with_label(label);
         gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(newMenuItem), true);
-    } else if (checked == false){
+    } else {
         newMenuItem = gtk_menu_item_new_with_label(label);
     }
     gtk_widget_destroy(menuItem);
 
     InstallMenuHandler(newMenuItem, browser, tag);
+
     model.setOsItem(tag, newMenuItem);
-	ExtensionString key = model.getKey(tag);
-	ExtensionString commandId = model.getCommandId(tag);
-	ParseShortcut(browser, newMenuItem, key, commandId);
+    ExtensionString key = model.getKey(tag);
+	ParseShortcut(browser, newMenuItem, key, command);
     gtk_menu_shell_insert(GTK_MENU_SHELL(parent), newMenuItem, position);
     gtk_widget_set_sensitive(newMenuItem, enabled);
     gtk_widget_show(newMenuItem);
@@ -1195,13 +1195,15 @@ int32 GetMenuTitle(CefRefPtr<CefBrowser> browser, ExtensionString commandId, Ext
 
 int32 SetMenuItemShortcut(CefRefPtr<CefBrowser> browser, ExtensionString commandId, ExtensionString shortcut, ExtensionString displayStr)
 {
-    NativeMenuModel model = NativeMenuModel::getInstance(getMenuParent(browser));
-    int32 tag = model.getTag(commandId);
+    NativeMenuModel& model = NativeMenuModel::getInstance(getMenuParent(browser));
+    int tag = model.getTag(commandId);
     if (tag == kTagNotFound) {
         return ERR_NOT_FOUND;
     }
     GtkWidget* entry = (GtkWidget*) model.getOsItem(tag);
+    model.setKey(tag, shortcut);
     ParseShortcut(browser, entry, shortcut, commandId);
+
     return NO_ERROR;
 }
 

--- a/appshell/native_menu_model.cpp
+++ b/appshell/native_menu_model.cpp
@@ -97,6 +97,22 @@ ExtensionString NativeMenuModel::getParentId(int tag) {
     return menuItems[tag].parentId;
 }
 
+ExtensionString NativeMenuModel::getKey(int tag) {
+    menu::iterator foundItem = menuItems.find(tag);
+    if(foundItem == menuItems.end()) {
+        return ExtensionString();
+    }
+    return menuItems[tag].key;
+}
+
+void NativeMenuModel::setKey (int tag, ExtensionString theKey) {
+    menu::iterator foundItem = menuItems.find(tag);
+    if(foundItem == menuItems.end()) {
+        return;
+    }
+    menuItems[tag].key = theKey;
+}
+
 int NativeMenuModel::getOrCreateTag(ExtensionString command, ExtensionString parent)
 {
     menuTag::iterator foundItem = commandMap.find(command);

--- a/appshell/native_menu_model.h
+++ b/appshell/native_menu_model.h
@@ -47,7 +47,7 @@ class NativeMenuItemModel
         osItem(NULL),
         commandId(commandId),
         parentId(parentId),
-		key(ExtensionString())
+        key(ExtensionString())
     {
     }
     bool checked;
@@ -55,7 +55,7 @@ class NativeMenuItemModel
     void *osItem;
     ExtensionString commandId;
     ExtensionString parentId;
-	ExtensionString key;
+    ExtensionString key;
 };
 
 //command name -> menutag
@@ -93,7 +93,7 @@ public:
     int setTag(ExtensionString command, ExtensionString parent, int tag);
     ExtensionString getCommandId(int tag);
     ExtensionString getParentId(int tag);
-	ExtensionString getKey(int tag);
+    ExtensionString getKey(int tag);
     void setKey(int tag, ExtensionString theKey);
     void setOsItem (int tag, void* theItem);
     void* getOsItem (int tag);

--- a/appshell/native_menu_model.h
+++ b/appshell/native_menu_model.h
@@ -46,7 +46,8 @@ class NativeMenuItemModel
         enabled(enabled),
         osItem(NULL),
         commandId(commandId),
-        parentId(parentId)
+        parentId(parentId),
+		key(ExtensionString())
     {
     }
     bool checked;
@@ -54,6 +55,7 @@ class NativeMenuItemModel
     void *osItem;
     ExtensionString commandId;
     ExtensionString parentId;
+	ExtensionString key;
 };
 
 //command name -> menutag
@@ -91,13 +93,10 @@ public:
     int setTag(ExtensionString command, ExtensionString parent, int tag);
     ExtensionString getCommandId(int tag);
     ExtensionString getParentId(int tag);
+	ExtensionString getKey(int tag);
+    void setKey(int tag, ExtensionString theKey);
     void setOsItem (int tag, void* theItem);
     void* getOsItem (int tag);
     
     int removeMenuItem(const ExtensionString& command);
 };
-
-
-
-
-


### PR DESCRIPTION
This PR makes the shortcuts to be shown again in the Linux native menus. Which were lost in my previous PR relative to the switchable menu entries.

A few shortcuts are still not shown. And honestly, at the moment I could not find the reason. Maybe someone can point out what I've missed.

The latter is more the reason for opening this PR than a merge in this state.

Thank you.