### PR TITLE
Fix full screen window issue in multiple montiors

### DIFF
--- a/appshell/cef_dark_aero_window.cpp
+++ b/appshell/cef_dark_aero_window.cpp
@@ -843,6 +843,10 @@ LRESULT cef_dark_aero_window::WindowProc(UINT message, WPARAM wParam, LPARAM lPa
                 return 0L;
         }
         break;
+	case WM_NCPAINT:
+		if (HandleNcPaint((HRGN)wParam))
+			return 0L;
+		break;
     }
 
     // call DefWindowProc?


### PR DESCRIPTION
Issue: https://github.com/adobe/brackets/issues/13349
- Currently we are not handling the WM_NCPAINT for dark aero glass. This causes the issue when we delegate this handling to the OS.
To fix this issue, I have added a handle for dark aero similar to the one present for dark window.

- This will also fix the following issue 
![brackets](https://user-images.githubusercontent.com/29909810/38730688-28399c62-3f35-11e8-8587-bdc0ca6abfe2.PNG)

The boundaries of the non client area is not correctly painted when we launch brackets in maximized window and go from maximize to restored window.
After the fix 
![brackets_fix](https://user-images.githubusercontent.com/29909810/38730817-a8d13a88-3f35-11e8-9cf7-dad2ff786fe3.PNG)
 
Unit tested the fix 
- On Win10 builds before and after creators update.
- On Dual monitors with different resolution
- On Dual monitors with one monitor with high DPI.

Please review @nethip @swmitra @vickramdhawal @JeffryBooher 