### PR TITLE
Disable custom drag handlers if OS is linux

### DIFF
--- a/appshell/browser/client_handler.cc
+++ b/appshell/browser/client_handler.cc
@@ -323,6 +323,7 @@ void ClientHandler::OnDownloadUpdated(
   }
 }
 
+#ifndef OS_LINUX
 bool ClientHandler::OnDragEnter(CefRefPtr<CefBrowser> browser,
                                 CefRefPtr<CefDragData> dragData,
                                 CefDragHandler::DragOperationsMask mask) {
@@ -334,6 +335,7 @@ bool ClientHandler::OnDragEnter(CefRefPtr<CefBrowser> browser,
 
   return false;
 }
+#endif
 
 void ClientHandler::OnDraggableRegionsChanged(
     CefRefPtr<CefBrowser> browser,

--- a/appshell/browser/client_handler.h
+++ b/appshell/browser/client_handler.h
@@ -105,9 +105,12 @@ class ClientHandler :
   CefRefPtr<CefDownloadHandler> GetDownloadHandler() OVERRIDE {
     return this;
   }
+  #ifndef OS_LINUX
   CefRefPtr<CefDragHandler> GetDragHandler() OVERRIDE {
     return this;
   }
+  #endif
+
   CefRefPtr<CefGeolocationHandler> GetGeolocationHandler() OVERRIDE {
     return this;
   }
@@ -173,9 +176,11 @@ class ClientHandler :
       CefRefPtr<CefDownloadItemCallback> callback) OVERRIDE;
 
   // CefDragHandler methods
+  #ifndef OS_LINUX
   bool OnDragEnter(CefRefPtr<CefBrowser> browser,
                    CefRefPtr<CefDragData> dragData,
                    CefDragHandler::DragOperationsMask mask) OVERRIDE;
+  #endif
 
   void OnDraggableRegionsChanged(
       CefRefPtr<CefBrowser> browser,

--- a/appshell/client_handler.cpp
+++ b/appshell/client_handler.cpp
@@ -188,6 +188,7 @@ void ClientHandler::OnBeforeClose(CefRefPtr<CefBrowser> browser) {
 
 std::vector<CefString> gDroppedFiles;
 
+#ifndef OS_LINUX
 bool ClientHandler::OnDragEnter(CefRefPtr<CefBrowser> browser,
                                 CefRefPtr<CefDragData> dragData,
                                 DragOperationsMask mask) {
@@ -200,6 +201,7 @@ bool ClientHandler::OnDragEnter(CefRefPtr<CefBrowser> browser,
     }
     return false;
 }
+#endif
 
 void ClientHandler::OnLoadStart(CefRefPtr<CefBrowser> browser,
                                 CefRefPtr<CefFrame> frame

--- a/appshell/client_handler.h
+++ b/appshell/client_handler.h
@@ -24,7 +24,9 @@
 // ClientHandler implementation.
 class ClientHandler : public CefClient,
                       public CefLifeSpanHandler,
+                      #ifndef OS_LINUX
                       public CefDragHandler,
+                      #endif
                       public CefLoadHandler,
                       public CefRequestHandler,
                       public CefDisplayHandler,
@@ -76,9 +78,13 @@ public:
   virtual CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() OVERRIDE {
     return this;
   }
+
+  #ifndef OS_LINUX
   virtual CefRefPtr<CefDragHandler> GetDragHandler() OVERRIDE {
     return this;
   }
+  #endif
+
   virtual CefRefPtr<CefLoadHandler> GetLoadHandler() OVERRIDE {
     return this;
   }
@@ -119,10 +125,12 @@ virtual bool OnBeforePopup(CefRefPtr<CefBrowser> browser,
   virtual void OnAfterCreated(CefRefPtr<CefBrowser> browser) OVERRIDE;
   virtual void OnBeforeClose(CefRefPtr<CefBrowser> browser) OVERRIDE;
   
+  #ifndef OS_LINUX
   // CefDragHandler methods
   virtual bool OnDragEnter(CefRefPtr<CefBrowser> browser,
                            CefRefPtr<CefDragData> dragData,
                            DragOperationsMask mask) OVERRIDE;
+  #endif
 
   // CefLoadHandler methods
   virtual void OnLoadStart(CefRefPtr<CefBrowser> browser,


### PR DESCRIPTION
This PR disables custom drag handlers to make CEF fallback to default behavior