### PR TITLE
Revert "Adding maint version to brackets win installer (#640)"

### DIFF
--- a/installer/win/brackets-win-install-build.xml
+++ b/installer/win/brackets-win-install-build.xml
@@ -13,9 +13,8 @@ default="build.mul">
   <property name="product.shortname" value="Brackets"/>
   <property name="product.release.number.major" value="1"/>
   <property name="product.release.number.minor" value="13"/>
-  <property name="product.release.number.maint" value="0"/>
   <property name="product.release.number.build" value="0"/>
-  <property name="product.version.number" value="${product.release.number.major}.${product.release.number.minor}.${product.release.number.maint}.${product.release.number.build}"/>
+  <property name="product.version.number" value="${product.release.number.major}.${product.release.number.minor}.${product.release.number.build}"/>
   <property name="product.version.name" value="Release ${product.release.number.major}.${product.release.number.minor}"/>
   <property name="product.fullname" value="Brackets ${product.version.name}"/>
   <property name="product.manufacturer" value="brackets.io"/>

--- a/tasks/set-release.js
+++ b/tasks/set-release.js
@@ -76,11 +76,6 @@ module.exports = function (grunt) {
             /<property name="product\.release\.number\.minor" value="(\d+)"\/>/,
             '<property name="product.release.number.minor" value="' + newVersion.minor + '"/>'
         );
-        text = safeReplace(
-            text,
-            /<property name="product\.release\.number\.maint" value="(\d+)"\/>/,
-            '<property name="product.release.number.maint" value="' + newVersion.patch + '"/>'
-        );
         grunt.file.write(winInstallerBuildXmlPath, text);
 
         // 3. Open installer/mac/buildInstaller.sh and change `dmgName`


### PR DESCRIPTION
This reverts commit 5be890b5fa752440dc993e735590c094ec136b49.

This combined with the addition of build number to the installer was causing
bugs for windows installer upgrade scenarios