### PR TITLE
Close file handle on unsupported encoding

### DIFF
--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -969,7 +969,7 @@ int32 ReadFile(ExtensionString filename, ExtensionString& encoding, std::string&
                                 detectedCharSet = conv.to_bytes(encoding);
                             }
                             if (detectedCharSet == "UTF-16LE" || detectedCharSet == "UTF-16BE") {
-								CloseHandle(hFile);
+				 CloseHandle(hFile);
                                 return ERR_UNSUPPORTED_UTF16_ENCODING;
                             }
                             std::transform(detectedCharSet.begin(), detectedCharSet.end(), detectedCharSet.begin(), ::toupper);

--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -969,6 +969,7 @@ int32 ReadFile(ExtensionString filename, ExtensionString& encoding, std::string&
                                 detectedCharSet = conv.to_bytes(encoding);
                             }
                             if (detectedCharSet == "UTF-16LE" || detectedCharSet == "UTF-16BE") {
+								CloseHandle(hFile);
                                 return ERR_UNSUPPORTED_UTF16_ENCODING;
                             }
                             std::transform(detectedCharSet.begin(), detectedCharSet.end(), detectedCharSet.begin(), ::toupper);


### PR DESCRIPTION
Fixes [#14244](https://github.com/adobe/brackets/issues/14244)

For some [specific](https://github.com/adobe/brackets-shell/blob/master/appshell/appshell_extensions_win.cpp#L971) encodings, the **file handle is not closed** which causes error code 32 (The process cannot access the file as it is used by some other process) while calling the MoveFile system function.

@vickramdhawal @swmitra Please review