### PR TITLE
Forcefully disabling renderer accesibility

### DIFF
--- a/appshell/cefclient.cpp
+++ b/appshell/cefclient.cpp
@@ -19,7 +19,10 @@
 #include "config.h"
 
 CefRefPtr<ClientHandler> g_handler;
-bool					 g_force_enable_acc = false;
+
+#ifdef OS_WIN
+bool g_force_enable_acc = false;
+#endif
 
 CefRefPtr<CefBrowser> AppGetBrowser() {
   if (!g_handler.get())
@@ -107,6 +110,7 @@ void AppGetSettings(CefSettings& settings, CefRefPtr<CefCommandLine> command_lin
     CefString(&settings.product_version) = versionStr;
   }
 
+#ifdef OS_WIN
   // We disable renderer accessibility by default as it is known to cause performance
   // issues. But if any one wants to enable it back, then we need to honor the flag.
 
@@ -115,5 +119,6 @@ void AppGetSettings(CefSettings& settings, CefRefPtr<CefCommandLine> command_lin
 
   if (HasSwitch(command_line, force_acc_switch_name) || HasSwitch(command_line, enable_acc_switch_name))
     g_force_enable_acc = true;
+#endif
 
 }

--- a/appshell/cefclient.cpp
+++ b/appshell/cefclient.cpp
@@ -33,16 +33,18 @@ CefWindowHandle AppGetMainHwnd() {
   return g_handler->GetMainHwnd();
 }
 
-// CefCommandLine::HasSwitch is unable to
-// report these switches properly. So instead
-// we will do a string search one the command
-// line string to figure out presense of any
-// particular flag.
+// CefCommandLine::HasSwitch is unable to report the presense of switches,
+// in the command line properly. This is a generic function that could be
+// used to check for any particular switch, passed as a command line argument.
 bool HasSwitch(CefRefPtr<CefCommandLine> command_line , CefString& switch_name)
 {
-  ExtensionString cmdLine = command_line->GetCommandLineString();
-  size_t idx = cmdLine.find(switch_name);
-  return idx > 0 && idx < cmdLine.length();
+  if (command_line) {
+    ExtensionString cmdLine = command_line->GetCommandLineString();
+    size_t idx = cmdLine.find(switch_name);
+    return idx > 0 && idx < cmdLine.length();
+  } else {
+    return false;
+  }
 }
 
 // Returns the application settings based on command line arguments.
@@ -105,11 +107,8 @@ void AppGetSettings(CefSettings& settings, CefRefPtr<CefCommandLine> command_lin
     CefString(&settings.product_version) = versionStr;
   }
 
-  // Also see if we need to extract force enable renderer accessibility flags.
   // We disable renderer accessibility by default as it is known to cause performance
   // issues. But if any one wants to enable it back, then we need to honor the flag.
-  std::vector<CefString> arguments_vec;
-  command_line->GetArguments(arguments_vec);
 
   CefString force_acc_switch_name("--force-renderer-accessibility");
   CefString enable_acc_switch_name("--enable-renderer-accessibility");

--- a/appshell/client_app.cpp
+++ b/appshell/client_app.cpp
@@ -16,6 +16,8 @@
 #include "appshell/appshell_extension_handler.h"
 #include "appshell/appshell_helpers.h"
 
+extern bool g_force_enable_acc;
+
 ClientApp::ClientApp() {
   CreateRenderDelegates(render_delegates_);
 }
@@ -46,13 +48,17 @@ void ClientApp::OnBeforeCommandLineProcessing(
 	const CefString& process_type,
 	CefRefPtr<CefCommandLine> command_line)
 {
-	command_line->AppendSwitch("disable-renderer-accessibility");
+	// Check if the user wants to enable renderer accessibility
+	// and if not, then disable renderer accessibility.
+  if (!g_force_enable_acc)
+    command_line->AppendSwitch("disable-renderer-accessibility");
 }
 
 void ClientApp::OnBeforeChildProcessLaunch(
 	CefRefPtr<CefCommandLine> command_line)
 {
-	command_line->AppendSwitch("disable-renderer-accessibility");
+  if (!g_force_enable_acc)
+    command_line->AppendSwitch("disable-renderer-accessibility");
 }
 
 void ClientApp::OnContextReleased(CefRefPtr<CefBrowser> browser,

--- a/appshell/client_app.cpp
+++ b/appshell/client_app.cpp
@@ -16,7 +16,9 @@
 #include "appshell/appshell_extension_handler.h"
 #include "appshell/appshell_helpers.h"
 
+#ifdef OS_WIN
 extern bool g_force_enable_acc;
+#endif
 
 ClientApp::ClientApp() {
   CreateRenderDelegates(render_delegates_);
@@ -48,17 +50,21 @@ void ClientApp::OnBeforeCommandLineProcessing(
 	const CefString& process_type,
 	CefRefPtr<CefCommandLine> command_line)
 {
-	// Check if the user wants to enable renderer accessibility
-	// and if not, then disable renderer accessibility.
+ #ifdef OS_WIN
+  // Check if the user wants to enable renderer accessibility
+  // and if not, then disable renderer accessibility.
   if (!g_force_enable_acc)
     command_line->AppendSwitch("disable-renderer-accessibility");
+ #endif
 }
 
 void ClientApp::OnBeforeChildProcessLaunch(
 	CefRefPtr<CefCommandLine> command_line)
 {
+#ifdef OS_WIN
   if (!g_force_enable_acc)
     command_line->AppendSwitch("disable-renderer-accessibility");
+#endif
 }
 
 void ClientApp::OnContextReleased(CefRefPtr<CefBrowser> browser,

--- a/appshell/client_app.cpp
+++ b/appshell/client_app.cpp
@@ -42,6 +42,19 @@ void ClientApp::OnContextCreated(CefRefPtr<CefBrowser> browser,
     (*it)->OnContextCreated(this, browser, frame, context);
 }
 
+void ClientApp::OnBeforeCommandLineProcessing(
+	const CefString& process_type,
+	CefRefPtr<CefCommandLine> command_line)
+{
+	command_line->AppendSwitch("disable-renderer-accessibility");
+}
+
+void ClientApp::OnBeforeChildProcessLaunch(
+	CefRefPtr<CefCommandLine> command_line)
+{
+	command_line->AppendSwitch("disable-renderer-accessibility");
+}
+
 void ClientApp::OnContextReleased(CefRefPtr<CefBrowser> browser,
                                 CefRefPtr<CefFrame> frame,
                                 CefRefPtr<CefV8Context> context) {

--- a/appshell/client_app.h
+++ b/appshell/client_app.h
@@ -102,6 +102,15 @@ private:
   }
   virtual CefRefPtr<CefRenderProcessHandler> GetRenderProcessHandler()
       OVERRIDE { return this; }
+  
+  virtual CefRefPtr<CefBrowserProcessHandler> GetBrowserProcessHandler()
+	  OVERRIDE { return this; }
+  virtual void OnBeforeCommandLineProcessing(
+	  const CefString& process_type,
+	  CefRefPtr<CefCommandLine> command_line);
+
+  virtual void OnBeforeChildProcessLaunch(
+	  CefRefPtr<CefCommandLine> command_line);
 
   // CefRenderProcessHandler methods.
   virtual void OnWebKitInitialized() OVERRIDE;


### PR DESCRIPTION
Windows update KB4343909 is leading to performance issues on some systems. This is because of accessiblity renderer tree getting created wrongly. So disabling this for now.

Thanks to @katoken-0215 for pointing this out.

@abhijitapte @swmitra Could you please review this?