### PR TITLE
Disabled remote-debugging by default and appshell.app.getRemoteDebuggingPort() needs a callback argument to work

### DIFF
--- a/appshell/appshell_extension_handler.h
+++ b/appshell/appshell_extension_handler.h
@@ -160,7 +160,7 @@ class AppShellExtensionHandler : public CefV8Handler {
                          CefString& exception) {
 
         // The only messages that are handled here is getElapsedMilliseconds(),
-        // GetCurrentLanguage(), GetApplicationSupportDirectory(), and GetRemoteDebuggingPort().
+        // GetCurrentLanguage(), and GetApplicationSupportDirectory().
         // All other messages are passed to the browser process.
         if (name == "GetElapsedMilliseconds") {
             retval = CefV8Value::CreateDouble(GetElapsedMilliseconds());
@@ -170,8 +170,6 @@ class AppShellExtensionHandler : public CefV8Handler {
             retval = CefV8Value::CreateString(AppGetSupportDirectory());
         } else if (name == "GetUserDocumentsDirectory") {
             retval = CefV8Value::CreateString(AppGetDocumentsDirectory());
-        } else if (name == "GetRemoteDebuggingPort") {
-            retval = CefV8Value::CreateInt(REMOTE_DEBUGGING_PORT);
         } else {
             // Pass all messages to the browser process. Look in appshell_extensions.cpp for implementation.
             CefRefPtr<CefBrowser> browser = CefV8Context::GetCurrentContext()->GetBrowser();

--- a/appshell/appshell_extensions.cpp
+++ b/appshell/appshell_extensions.cpp
@@ -842,6 +842,8 @@ public:
             uberDict->SetList(0, dirContents);
             uberDict->SetList(1, allStats);
             responseArgs->SetList(2, uberDict);
+        } else if (message_name == "GetRemoteDebuggingPort") {
+            responseArgs->SetInt(2, g_remote_debugging_port);
         }
 
         else {

--- a/appshell/appshell_extensions.cpp
+++ b/appshell/appshell_extensions.cpp
@@ -37,6 +37,7 @@
 #include "update.h"
 
 extern std::vector<CefString> gDroppedFiles;
+extern int g_remote_debugging_port;
 
 namespace appshell_extensions {
 

--- a/appshell/appshell_extensions.js
+++ b/appshell/appshell_extensions.js
@@ -640,8 +640,8 @@ if (!brackets) {
      * @return int. The remote debugging port used by the appshell.
      */
     native function GetRemoteDebuggingPort();
-    appshell.app.getRemoteDebuggingPort = function () {
-        return GetRemoteDebuggingPort();
+    appshell.app.getRemoteDebuggingPort = function (callback) {
+        GetRemoteDebuggingPort(callback || _dummyCallback);
     };
     
     

--- a/appshell/cefclient.cpp
+++ b/appshell/cefclient.cpp
@@ -7,7 +7,6 @@
 #include <cstdlib>
 #include <sstream>
 #include <string>
-#include <limits>
 #include "include/cef_app.h"
 #include "include/cef_browser.h"
 #include "include/cef_command_line.h"
@@ -24,7 +23,6 @@ int g_remote_debugging_port = 0;
 
 #ifdef OS_WIN
 bool g_force_enable_acc = false;
-#undef max
 #endif
 
 CefRefPtr<CefBrowser> AppGetBrowser() {
@@ -101,14 +99,16 @@ void AppGetSettings(CefSettings& settings, CefRefPtr<CefCommandLine> command_lin
   CefString debugger_port = command_line->GetSwitchValue("remote-debugging-port");
   if (!debugger_port.empty()) {
     int port = atoi(debugger_port.ToString().c_str());
-    static const int max_port_num = static_cast<int>(std::numeric_limits<uint16_t>::max());
-    if (port > 1024 && port < max_port_num) {
+    static const int max_port_num = 65535;
+    static const int max_reserved_port_num = 1024;
+    if (port > max_reserved_port_num && port < max_port_num) {
       g_remote_debugging_port = port;
       settings.remote_debugging_port = port;
     }
     else {
       LOG(ERROR) << "Could not enable remote debugging on port: "<< port
-                 << "; port number must be greater than 1024 and less than " << max_port_num;
+                 << "; port number must be greater than "<< max_reserved_port_num
+                 << "and less than " << max_port_num;
     }
   }
   

--- a/appshell/cefclient.cpp
+++ b/appshell/cefclient.cpp
@@ -106,9 +106,9 @@ void AppGetSettings(CefSettings& settings, CefRefPtr<CefCommandLine> command_lin
       settings.remote_debugging_port = port;
     }
     else {
-      LOG(ERROR) << "Could not enable remote debugging on port: "<< port
-                 << "; port number must be greater than "<< max_reserved_port_num
-                 << " and less than " << max_port_num;
+      LOG(ERROR) << "Could not enable Remote debugging on port: "<< port
+                 << ". Port number must be greater than "<< max_reserved_port_num
+                 << " and less than " << max_port_num << ".";
     }
   }
   

--- a/appshell/cefclient.cpp
+++ b/appshell/cefclient.cpp
@@ -100,20 +100,23 @@ void AppGetSettings(CefSettings& settings, CefRefPtr<CefCommandLine> command_lin
   CefString debugger_port = command_line->GetSwitchValue("remote-debugging-port");
   if (!debugger_port.empty()) {
     const long port = strtol(debugger_port.ToString().c_str(), NULL, 10);
-    if (errno == ERANGE) {
+    if (errno == ERANGE || port == 0) {
+        LOG(ERROR) << "Could not enable Remote debugging.";
         LOG(ERROR) << "Error while parsing remote-debugging-port arg: "<< debugger_port.ToString();
         errno = 0;
     }
-    static const long max_port_num = 65535;
-    static const long max_reserved_port_num = 1024;
-    if (port > max_reserved_port_num && port < max_port_num) {
-      g_remote_debugging_port = static_cast<int>(port);
-      settings.remote_debugging_port = g_remote_debugging_port;
-    }
     else {
-      LOG(ERROR) << "Could not enable Remote debugging on port: "<< port
-                 << ". Port number must be greater than "<< max_reserved_port_num
-                 << " and less than " << max_port_num << ".";
+        static const long max_port_num = 65535;
+        static const long max_reserved_port_num = 1024;
+        if (port > max_reserved_port_num && port < max_port_num) {
+          g_remote_debugging_port = static_cast<int>(port);
+          settings.remote_debugging_port = g_remote_debugging_port;
+        }
+        else {
+          LOG(ERROR) << "Could not enable Remote debugging on port: "<< port
+                     << ". Port number must be greater than "<< max_reserved_port_num
+                     << " and less than " << max_port_num << ".";
+        }
     }
   }
   

--- a/appshell/cefclient.cpp
+++ b/appshell/cefclient.cpp
@@ -108,7 +108,7 @@ void AppGetSettings(CefSettings& settings, CefRefPtr<CefCommandLine> command_lin
     else {
       LOG(ERROR) << "Could not enable remote debugging on port: "<< port
                  << "; port number must be greater than "<< max_reserved_port_num
-                 << "and less than " << max_port_num;
+                 << " and less than " << max_port_num;
     }
   }
   

--- a/appshell/config.h
+++ b/appshell/config.h
@@ -82,7 +82,7 @@
 
 #endif
 
-#define REMOTE_DEBUGGING_PORT 9234
+extern int g_remote_debugging_port;
 
 // Comment out this line to enable OS themed drawing
 #define DARK_UI 

--- a/appshell/config.h
+++ b/appshell/config.h
@@ -82,8 +82,6 @@
 
 #endif
 
-extern int g_remote_debugging_port;
-
 // Comment out this line to enable OS themed drawing
 #define DARK_UI 
 #define DARK_AERO_GLASS


### PR DESCRIPTION
* Disabling remote debugging by default, and it can be enabled by passing a command line arg as --remote-debugging-port=xxxx
* Changed appshell.app.getRemoteDebuggingPort() implementation to require a callback
* Added validation for port range, and also without remote-debugging-port we will not be able to debug brackets using a browser, and if browser debugging is disabled, appshell.app.getRemoteDebuggingPort(callback) will print 0