### PR TITLE
moving command line error to infobar

### DIFF
--- a/appshell/appshell_extensions.cpp
+++ b/appshell/appshell_extensions.cpp
@@ -38,6 +38,7 @@
 
 extern std::vector<CefString> gDroppedFiles;
 extern int g_remote_debugging_port;
+extern std::string g_remote_debugging_port_invalid;
 
 namespace appshell_extensions {
 
@@ -844,7 +845,15 @@ public:
             uberDict->SetList(1, allStats);
             responseArgs->SetList(2, uberDict);
         } else if (message_name == "GetRemoteDebuggingPort") {
-            responseArgs->SetInt(2, g_remote_debugging_port);
+            if (g_remote_debugging_port > 0) {
+                responseArgs->SetInt(2, g_remote_debugging_port);
+            } else {
+                responseArgs->SetNull(2);
+                if (g_remote_debugging_port_invalid.size() > 0) {
+                    error = ERR_UNKNOWN;
+                    responseArgs->SetString(3, g_remote_debugging_port_invalid);
+               }
+            }
         }
 
         else {

--- a/appshell/cefclient.cpp
+++ b/appshell/cefclient.cpp
@@ -106,9 +106,15 @@ void AppGetSettings(CefSettings& settings, CefRefPtr<CefCommandLine> command_lin
         errno = 0;
     }
     else {
-        static const long max_port_num = 65534;
-        static const long max_reserved_port_num = 1024;
-        if (port >= max_reserved_port_num && port <= max_port_num) {
+        const long max_allowed_debug_port_num = 65534;
+#ifdef OS_WIN
+           // As of CEF-2623 Windows allows all positive port numbers less than 65534
+           // Please validate this before migrating to new CEF version
+           const long min_allowed_debug_port_num = 1;
+#else
+           const long min_allowed_debug_port_num = 1024;
+#endif
+        if (port >= min_allowed_debug_port_num && port <= max_allowed_debug_port_num) {
           g_remote_debugging_port = static_cast<int>(port);
           settings.remote_debugging_port = g_remote_debugging_port;
           g_remote_debugging_port_invalid.clear();

--- a/appshell/cefclient.cpp
+++ b/appshell/cefclient.cpp
@@ -21,6 +21,7 @@
 
 CefRefPtr<ClientHandler> g_handler;
 int g_remote_debugging_port = 0;
+std::string g_remote_debugging_port_invalid;
 
 #ifdef OS_WIN
 bool g_force_enable_acc = false;
@@ -99,23 +100,18 @@ void AppGetSettings(CefSettings& settings, CefRefPtr<CefCommandLine> command_lin
   // Enable dev tools
   CefString debugger_port = command_line->GetSwitchValue("remote-debugging-port");
   if (!debugger_port.empty()) {
-    const long port = strtol(debugger_port.ToString().c_str(), NULL, 10);
+    g_remote_debugging_port_invalid = debugger_port.ToString();
+    const long port = strtol(g_remote_debugging_port_invalid.c_str(), NULL, 10);
     if (errno == ERANGE || port == 0) {
-        LOG(ERROR) << "Could not enable remote debugging."
-                   << " Error while parsing remote-debugging-port arg: "<< debugger_port.ToString();
         errno = 0;
     }
     else {
         static const long max_port_num = 65534;
-        static const long max_reserved_port_num = 1025;
+        static const long max_reserved_port_num = 1024;
         if (port >= max_reserved_port_num && port <= max_port_num) {
           g_remote_debugging_port = static_cast<int>(port);
           settings.remote_debugging_port = g_remote_debugging_port;
-        }
-        else {
-          LOG(ERROR) << "Cannot enable remote debugging on port "<< port
-                     << ". Port numbers should be between "<< max_reserved_port_num
-                     << " and " << max_port_num << ".";
+          g_remote_debugging_port_invalid.clear();
         }
     }
   }


### PR DESCRIPTION
Moved port validation errors to infobar
Also CEF version used for Brackets, lack proper port validation logic(It is fixed from 3202), CEF relies on Operating System to block opening reserved ports:
This allows Brackets to open any positive number port less than 65535 on Windows, so for Win port range is [1,65534].
Mac and Linux do throw error while calling `bind()` on reserved ports, so for Mac and Linux port range is [1024,65534].

Despite issues with Windows port range, we should continue showing valid port range to be [1024,65535] on info-bar.