### PR TITLE
moving command line error to infobar and fixing windows port range issues

### DIFF
--- a/appshell/appshell_extensions.cpp
+++ b/appshell/appshell_extensions.cpp
@@ -58,7 +58,7 @@ public:
         CefRefPtr<CefListValue> argList = message->GetArgumentList();
         int32 callbackId = -1;
         int32 error = NO_ERROR;
-		std::string errInfo;
+        std::string errInfo;
         CefRefPtr<CefProcessMessage> response = 
             CefProcessMessage::Create("invokeCallback");
         CefRefPtr<CefListValue> responseArgs = response->GetArgumentList();
@@ -852,7 +852,6 @@ public:
             else {
                 responseArgs->SetNull(2);
                 errInfo = g_remote_debugging_port_invalid_arg;
-                error = ERR_UNKNOWN;
             }
         }
 

--- a/appshell/appshell_extensions.cpp
+++ b/appshell/appshell_extensions.cpp
@@ -38,7 +38,7 @@
 
 extern std::vector<CefString> gDroppedFiles;
 extern int g_remote_debugging_port;
-extern std::string g_remote_debugging_port_invalid_arg;
+extern std::string g_get_remote_debugging_port_error;
 
 namespace appshell_extensions {
 
@@ -846,12 +846,12 @@ public:
             uberDict->SetList(1, allStats);
             responseArgs->SetList(2, uberDict);
         } else if (message_name == "GetRemoteDebuggingPort") {
-            if (g_remote_debugging_port_invalid_arg.empty() && g_remote_debugging_port > 0) {
+            if (g_get_remote_debugging_port_error.empty() && g_remote_debugging_port > 0) {
                 responseArgs->SetInt(2, g_remote_debugging_port);
             }
             else {
                 responseArgs->SetNull(2);
-                errInfo = g_remote_debugging_port_invalid_arg;
+                errInfo = g_get_remote_debugging_port_error;
             }
         }
 
@@ -865,7 +865,6 @@ public:
                 responseArgs->SetInt(1, error);
             }
             else {
-                // Cef is not allowing to set CefDictionaryValue as error-info.
                 responseArgs->SetString(1, errInfo);
             }
 

--- a/appshell/cefclient.cpp
+++ b/appshell/cefclient.cpp
@@ -21,7 +21,7 @@
 
 CefRefPtr<ClientHandler> g_handler;
 int g_remote_debugging_port = 0;
-std::string g_remote_debugging_port_invalid_arg;
+std::string g_get_remote_debugging_port_error;
 
 #ifdef OS_WIN
 bool g_force_enable_acc = false;
@@ -100,8 +100,8 @@ void AppGetSettings(CefSettings& settings, CefRefPtr<CefCommandLine> command_lin
   // Enable dev tools
   CefString debugger_port = command_line->GetSwitchValue("remote-debugging-port");
   if (!debugger_port.empty()) {
-    g_remote_debugging_port_invalid_arg = debugger_port.ToString();
-    long port = strtol(g_remote_debugging_port_invalid_arg.c_str(), NULL, 10);
+    g_get_remote_debugging_port_error = debugger_port.ToString();
+    long port = strtol(g_get_remote_debugging_port_error.c_str(), NULL, 10);
     if (errno == ERANGE) {
       errno = port = 0;
     }
@@ -110,7 +110,7 @@ void AppGetSettings(CefSettings& settings, CefRefPtr<CefCommandLine> command_lin
     if (port > max_reserved_port_num && port < max_port_num) {
       g_remote_debugging_port = static_cast<int>(port);
       settings.remote_debugging_port = g_remote_debugging_port;
-      g_remote_debugging_port_invalid_arg.clear();
+      g_get_remote_debugging_port_error.clear();
     }
     else {
       // Setting debugging port to highest number will disable remote debugging


### PR DESCRIPTION
Windows was allowing Brackets to open a remote debugging port on any port in the range [1,65534], which was troubling.
So, have started setting `settings.remote_debugging_port=65535` in case of ports outside the interval [1024,65534].
Which stops Brackets from opening a reserved port and this stops error thrown in `bind()` on Linux and Mac.