### PR TITLE
Shell Api to get default Application for a file type

### DIFF
--- a/appshell/appshell_extensions.cpp
+++ b/appshell/appshell_extensions.cpp
@@ -433,23 +433,23 @@ public:
             }
             
         } else if (message_name == "getSystemDefaultApp") {
-			// Parameters:
-			//  0: int32 - callback id
-			//  1: string - list of file extensions
-			if (argList->GetSize() != 2 ||
-				argList->GetType(1) != VTYPE_STRING) {
-				error = ERR_INVALID_PARAMS;
-			}
+            // Parameters:
+            //  0: int32 - callback id
+            //  1: string - list of file extensions
+            if (argList->GetSize() != 2 ||
+                argList->GetType(1) != VTYPE_STRING) {
+                error = ERR_INVALID_PARAMS;
+            }
 
-			ExtensionString defaultApp;
-			if (error == NO_ERROR) {
-				error = getSystemDefaultApp(argList->GetString(1), defaultApp);
-			}
+            ExtensionString defaultApp;
+            if (error == NO_ERROR) {
+                error = getSystemDefaultApp(argList->GetString(1), defaultApp);
+            }
 
-			// Set response args for this function
-			responseArgs->SetString(2, defaultApp);
+            // Set response args for this function
+            responseArgs->SetString(2, defaultApp);
 
-		} else if (message_name == "QuitApplication") {
+        } else if (message_name == "QuitApplication") {
             // Parameters - none
 
             // The DispatchCloseToNextBrowser() call initiates a quit sequence. The app will

--- a/appshell/appshell_extensions.cpp
+++ b/appshell/appshell_extensions.cpp
@@ -432,7 +432,24 @@ public:
                 responseArgs->SetInt(2, port);
             }
             
-        } else if (message_name == "QuitApplication") {
+        } else if (message_name == "getSystemDefaultApp") {
+			// Parameters:
+			//  0: int32 - callback id
+			//  1: string - list of file extensions
+			if (argList->GetSize() != 2 ||
+				argList->GetType(1) != VTYPE_STRING) {
+				error = ERR_INVALID_PARAMS;
+			}
+
+			ExtensionString defaultApp;
+			if (error == NO_ERROR) {
+				error = getSystemDefaultApp(argList->GetString(1), defaultApp);
+			}
+
+			// Set response args for this function
+			responseArgs->SetString(2, defaultApp);
+
+		} else if (message_name == "QuitApplication") {
             // Parameters - none
 
             // The DispatchCloseToNextBrowser() call initiates a quit sequence. The app will

--- a/appshell/appshell_extensions.js
+++ b/appshell/appshell_extensions.js
@@ -376,6 +376,26 @@ if (!brackets) {
     };
 
     /**
+     * Checks If fileytype has assigned system default app
+     *
+     * @param {string} filetypes list of file Types for which deafult app to checked.
+     * @param {function(err)} callback Asynchronous callback function. The callback gets two arguments 
+     *        (filetypes, err)
+     *        filetypes which has system default app assigned.
+     *
+     *        Possible error values:
+     *          NO_ERROR
+     *          ERR_INVALID_PARAMS
+     *          ERR_NOT_FOUND
+     *
+     * @return None. This is an asynchronous call that sends all return information to the callback.
+     */
+    native function getSystemDefaultApp();
+        appshell.app.getSystemDefaultApp = function (filetypes, callback) {
+            getSystemDefaultApp(callback || _dummyCallback, filetypes);
+    };
+
+    /**
      * Quits native shell application
      */
     native function QuitApplication();

--- a/appshell/appshell_extensions_gtk.cpp
+++ b/appshell/appshell_extensions_gtk.cpp
@@ -210,7 +210,7 @@ int32 OpenURLInDefaultBrowser(ExtensionString url)
     return NO_ERROR;
 }
 
-int32 getSystemDefaultApp(ExtensionString fileTypes, ExtensionString& fileTypesWithdefaultApp)
+int32 getSystemDefaultApp(const ExtensionString& fileTypes, ExtensionString& fileTypesWithdefaultApp)
 {
 	return NO_ERROR;
 }

--- a/appshell/appshell_extensions_gtk.cpp
+++ b/appshell/appshell_extensions_gtk.cpp
@@ -210,6 +210,11 @@ int32 OpenURLInDefaultBrowser(ExtensionString url)
     return NO_ERROR;
 }
 
+int32 getSystemDefaultApp(ExtensionString fileTypes, ExtensionString& fileTypesWithdefaultApp)
+{
+	return NO_ERROR;
+}
+
 int32 IsNetworkDrive(ExtensionString path, bool& isRemote)
 {
     return NO_ERROR;

--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -424,7 +424,7 @@ int32 getSystemDefaultApp(ExtensionString fileTypes, ExtensionString& fileTypesW
 
                 if (bundle)
                 {
-                    appPath = [(NSString *)[bundle objectForInfoDictionaryKey: @"CFBundleIdentifier"] cStringUsingEncoding:NSUTF8StringEncoding];
+                    appPath = [(NSString *)[bundle objectForInfoDictionaryKey: @"CFBundleExecutable"] cStringUsingEncoding:NSUTF8StringEncoding];
                 }
 
                 fileTypesWithdefaultApp = fileTypesWithdefaultApp + *it + separator + appPath + ",";

--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -391,7 +391,7 @@ void CloseLiveBrowser(CefRefPtr<CefBrowser> browser, CefRefPtr<CefProcessMessage
                                          );
 }
 
-int32 getSystemDefaultApp(ExtensionString fileTypes, ExtensionString& fileTypesWithdefaultApp)
+int32 getSystemDefaultApp(const ExtensionString& fileTypes, ExtensionString& fileTypesWithdefaultApp)
 {
 
     char delim[] = ",";
@@ -403,11 +403,14 @@ int32 getSystemDefaultApp(ExtensionString fileTypes, ExtensionString& fileTypesW
         token = std::strtok(NULL, delim);
     }
 
-    for (std::vector<ExtensionString>::iterator it = extArray.begin(); it != extArray.end(); ++it)
+    for (std::vector<ExtensionString>::const_iterator it = extArray.begin(); it != extArray.end(); ++it)
     {
         ExtensionString appPath;
 
         CFStringRef contentType = CFStringCreateWithCString (NULL, (*it).c_str(), kCFStringEncodingUTF8);
+
+        if(!contentType)
+            continue;
 
         CFStringRef UTI = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension,
                                                                            contentType,

--- a/appshell/appshell_extensions_mac.mm
+++ b/appshell/appshell_extensions_mac.mm
@@ -391,6 +391,59 @@ void CloseLiveBrowser(CefRefPtr<CefBrowser> browser, CefRefPtr<CefProcessMessage
                                          );
 }
 
+int32 getSystemDefaultApp(ExtensionString fileTypes, ExtensionString& fileTypesWithdefaultApp)
+{
+
+    char delim[] = ",";
+    char separator[] = "##";
+    std::vector<ExtensionString> extArray;
+    char* token = std::strtok((char*)fileTypes.c_str(), delim);
+    while (token) {
+        extArray.push_back(token);
+        token = std::strtok(NULL, delim);
+    }
+
+    for (std::vector<ExtensionString>::iterator it = extArray.begin(); it != extArray.end(); ++it)
+    {
+        ExtensionString appPath;
+
+        CFStringRef contentType = CFStringCreateWithCString (NULL, (*it).c_str(), kCFStringEncodingUTF8);
+
+        CFStringRef UTI = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension,
+                                                                           contentType,
+                                                                           NULL);
+        if(UTI)
+        {
+            CFURLRef bundle_id;
+
+            bundle_id = LSCopyDefaultApplicationURLForContentType(UTI, kLSRolesEditor, NULL);
+
+            if(bundle_id)
+            {
+                NSBundle *bundle = [NSBundle bundleWithURL: (NSURL*)bundle_id];
+
+                if (bundle)
+                {
+                    appPath = [(NSString *)[bundle objectForInfoDictionaryKey: @"CFBundleIdentifier"] cStringUsingEncoding:NSUTF8StringEncoding];
+                }
+
+                fileTypesWithdefaultApp = fileTypesWithdefaultApp + *it + separator + appPath + ",";
+
+                CFRelease(bundle_id);
+            }
+
+            CFRelease(UTI);
+        }
+
+        CFRelease(contentType);
+    }
+
+    return NO_ERROR;
+}
+
+
+
+
 int32 OpenURLInDefaultBrowser(ExtensionString url)
 {
     NSString* urlString = [NSString stringWithUTF8String:url.c_str()];

--- a/appshell/appshell_extensions_platform.h
+++ b/appshell/appshell_extensions_platform.h
@@ -192,7 +192,7 @@ void MoveFileOrDirectoryToTrash(ExtensionString filename, CefRefPtr<CefBrowser> 
 
 int32 CopyFile(ExtensionString src, ExtensionString dest);
 
-int32 getSystemDefaultApp(ExtensionString fileTypes, ExtensionString& fileTypesWithdefaultApp);
+int32 getSystemDefaultApp(const ExtensionString& fileTypes, ExtensionString& fileTypesWithdefaultApp);
 
 int32 GetNodeState(int32& state);
 

--- a/appshell/appshell_extensions_platform.h
+++ b/appshell/appshell_extensions_platform.h
@@ -192,6 +192,8 @@ void MoveFileOrDirectoryToTrash(ExtensionString filename, CefRefPtr<CefBrowser> 
 
 int32 CopyFile(ExtensionString src, ExtensionString dest);
 
+int32 getSystemDefaultApp(ExtensionString fileTypes, ExtensionString& fileTypesWithdefaultApp);
+
 int32 GetNodeState(int32& state);
 
 void OnBeforeShutdown();

--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -497,6 +497,7 @@ BOOL GetLegacyWin32SystemEditor(const ExtensionString& fileExt, ExtensionString 
     HKEY	rootKey;
     ULONG	regKey(REG_SZ);
 	ExtensionString key = fileExt;
+	BOOL	result = FALSE;
 
     if (fileExt[0] != '.')
 		key = L"." + key;
@@ -510,6 +511,7 @@ BOOL GetLegacyWin32SystemEditor(const ExtensionString& fileExt, ExtensionString 
         if (RegQueryValueEx(rootKey, L"", NULL, &regKey,
             (LPBYTE)nextKeyStr, &strSize) == ERROR_SUCCESS)
         {
+			RegCloseKey(rootKey);
             return ResolveAppPathFromProgID(nextKeyStr, appPath);
         }
         RegCloseKey(rootKey);
@@ -527,8 +529,8 @@ BOOL GetLegacyWin32SystemEditor(const ExtensionString& fileExt, ExtensionString 
             0, 0, 0, NULL);
         if (err != ERROR_NO_MORE_ITEMS)
         {
+			RegCloseKey(extKey);
             return ResolveAppPathFromProgID(subKeyStr, appPath);
-
         }
 
         RegCloseKey(extKey);

--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -445,8 +445,7 @@ static BOOL ResolveAppPathCommon(const ExtensionString& lpszKey, const Extension
 static BOOL ResolveAppPathFromProgID(const ExtensionString& lpszProgID, ExtensionString& appPath)
 {
 
-    ExtensionString key;
-    key = lpszProgID + L"\\shell\\open\\command";
+    ExtensionString key = lpszProgID + L"\\shell\\open\\command";
 
 
     if (!ResolveAppPathCommon(key, L"", appPath))
@@ -468,6 +467,9 @@ BOOL GetShellDefaultOpenWithProgPath(const ExtensionString& fileExt, ExtensionSt
     ExtensionString key = fileExt;
     BOOL	result = FALSE;
     ULONG	regKey(REG_SZ);
+
+    if (fileExt.empty())
+        return false;
 
     if (fileExt[0] != '.')
         key = L"." + fileExt;
@@ -497,6 +499,9 @@ BOOL GetLegacyWin32SystemEditor(const ExtensionString& fileExt, ExtensionString 
     HKEY	rootKey;
     ULONG	regKey(REG_SZ);
     ExtensionString key = fileExt;
+
+    if (fileExt.empty())
+        return false;
 
     if (fileExt[0] != '.')
         key = L"." + key;

--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -465,14 +465,14 @@ static BOOL ResolveAppPathFromProgID(const ExtensionString& lpszProgID, Extensio
 BOOL GetShellDefaultOpenWithProgPath(const ExtensionString& fileExt, ExtensionString &appPath)
 {
     HKEY	extKey = NULL;
-    ExtensionString key;
+    ExtensionString key = fileExt;
     BOOL	result = FALSE;
     ULONG	regKey(REG_SZ);
 
     if (fileExt[0] != '.')
-        fileExt = L"." + fileExt;
+		key = L"." + fileExt;
 
-    key = L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts\\" +  fileExt + L"\\UserChoice";
+    key = L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts\\" + key + L"\\UserChoice";
 
     if (::RegOpenKeyEx(HKEY_CURRENT_USER, key.c_str(), 0, KEY_QUERY_VALUE, &extKey) == ERROR_SUCCESS)
     {
@@ -496,12 +496,13 @@ BOOL GetLegacyWin32SystemEditor(const ExtensionString& fileExt, ExtensionString 
 {
     HKEY	rootKey;
     ULONG	regKey(REG_SZ);
+	ExtensionString key = fileExt;
 
     if (fileExt[0] != '.')
-        fileExt = L"." + fileExt;
+		key = L"." + key;
 
     // find the key for the file extension
-    if (RegOpenKeyEx(HKEY_CLASSES_ROOT, fileExt.c_str(), 0, KEY_QUERY_VALUE, &rootKey) == ERROR_SUCCESS)
+    if (RegOpenKeyEx(HKEY_CLASSES_ROOT, key.c_str(), 0, KEY_QUERY_VALUE, &rootKey) == ERROR_SUCCESS)
     {
         TCHAR nextKeyStr[255];
         ULONG strSize = 255;
@@ -514,10 +515,10 @@ BOOL GetLegacyWin32SystemEditor(const ExtensionString& fileExt, ExtensionString 
         RegCloseKey(rootKey);
     }
 
-    fileExt = fileExt+ L"\\OpenWithProgids";
+	key = key + L"\\OpenWithProgids";
     HKEY extKey;
     // find the key for the file extension
-    if (RegOpenKeyEx(HKEY_CLASSES_ROOT, fileExt.c_str(), 0, KEY_QUERY_VALUE | KEY_READ, &extKey) == ERROR_SUCCESS)
+    if (RegOpenKeyEx(HKEY_CLASSES_ROOT, key.c_str(), 0, KEY_QUERY_VALUE | KEY_READ, &extKey) == ERROR_SUCCESS)
     {
         TCHAR subKeyStr[255];
         ULONG subKeySize = 255;

--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -554,7 +554,7 @@ int32 getSystemDefaultApp(ExtensionString fileTypes, ExtensionString& fileTypesW
 			result = GetLegacyWin32SystemEditor(*it, appPath);
 
 		if (result)
-			fileTypesWithdefaultApp = fileTypesWithdefaultApp + *it + L":" + appPath + L",";
+			fileTypesWithdefaultApp = fileTypesWithdefaultApp + *it + L"##" + appPath + L",";
 	}
 
 	return true;

--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -470,7 +470,7 @@ BOOL GetShellDefaultOpenWithProgPath(const ExtensionString& fileExt, ExtensionSt
     ULONG	regKey(REG_SZ);
 
     if (fileExt[0] != '.')
-		key = L"." + fileExt;
+        key = L"." + fileExt;
 
     key = L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts\\" + key + L"\\UserChoice";
 
@@ -496,11 +496,10 @@ BOOL GetLegacyWin32SystemEditor(const ExtensionString& fileExt, ExtensionString 
 {
     HKEY	rootKey;
     ULONG	regKey(REG_SZ);
-	ExtensionString key = fileExt;
-	BOOL	result = FALSE;
+    ExtensionString key = fileExt;
 
     if (fileExt[0] != '.')
-		key = L"." + key;
+        key = L"." + key;
 
     // find the key for the file extension
     if (RegOpenKeyEx(HKEY_CLASSES_ROOT, key.c_str(), 0, KEY_QUERY_VALUE, &rootKey) == ERROR_SUCCESS)
@@ -511,13 +510,13 @@ BOOL GetLegacyWin32SystemEditor(const ExtensionString& fileExt, ExtensionString 
         if (RegQueryValueEx(rootKey, L"", NULL, &regKey,
             (LPBYTE)nextKeyStr, &strSize) == ERROR_SUCCESS)
         {
-			RegCloseKey(rootKey);
+            RegCloseKey(rootKey);
             return ResolveAppPathFromProgID(nextKeyStr, appPath);
         }
         RegCloseKey(rootKey);
     }
 
-	key = key + L"\\OpenWithProgids";
+    key = key + L"\\OpenWithProgids";
     HKEY extKey;
     // find the key for the file extension
     if (RegOpenKeyEx(HKEY_CLASSES_ROOT, key.c_str(), 0, KEY_QUERY_VALUE | KEY_READ, &extKey) == ERROR_SUCCESS)
@@ -529,7 +528,7 @@ BOOL GetLegacyWin32SystemEditor(const ExtensionString& fileExt, ExtensionString 
             0, 0, 0, NULL);
         if (err != ERROR_NO_MORE_ITEMS)
         {
-			RegCloseKey(extKey);
+            RegCloseKey(extKey);
             return ResolveAppPathFromProgID(subKeyStr, appPath);
         }
 

--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -427,6 +427,9 @@ static BOOL ResolveAppPathCommon(ExtensionString lpszKey, ExtensionString lpszVa
                 if (iExe != -1)
                     appPath = appPath.substr(0, iExe+4);
 
+                if (appPath[0] == '\"')
+                    appPath = appPath.substr(1);
+
                 result = TRUE;
             }
 

--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -403,6 +403,164 @@ void CloseLiveBrowser(CefRefPtr<CefBrowser> browser, CefRefPtr<CefProcessMessage
     }
 }
 
+// 
+static BOOL ResolveAppPathCommon(ExtensionString lpszKey, ExtensionString lpszVal, ExtensionString& appPath)
+{
+
+	HKEY	keyRoot = NULL;
+	BOOL	result = FALSE;
+	ULONG	regKey(REG_SZ);
+
+	if (::RegOpenKeyEx(HKEY_CLASSES_ROOT, lpszKey.c_str(), 0, KEY_QUERY_VALUE, &keyRoot) == ERROR_SUCCESS)
+	{
+		TCHAR editorPath[255];
+		ULONG fTypeSize = 255;
+
+		if (::RegQueryValueEx(keyRoot, lpszVal.c_str(), NULL, &regKey, (LPBYTE)editorPath, &fTypeSize) == ERROR_SUCCESS)
+		{
+			if (editorPath != L"")
+			{
+				appPath = editorPath;
+				appPath = appPath.substr(appPath.find_last_of(L"/\\") + 1);
+				int iExe = appPath.find(L".exe");
+				if (iExe == -1)
+					iExe = appPath.find(L".EXE");
+				if (iExe != -1)
+					appPath = appPath.substr(0, iExe);
+
+				result = TRUE;
+			}
+
+
+		}
+		::RegCloseKey(keyRoot);
+	}
+
+	return result;
+
+}
+
+static BOOL ResolveAppPathFromProgID(ExtensionString lpszProgID, ExtensionString& appPath)
+{
+
+	ExtensionString key;
+	key = lpszProgID + L"\\shell\\open\\command";
+
+
+	if (!ResolveAppPathCommon(key, L"", appPath))
+	{
+		key = lpszProgID + L"\\Application";
+		if (ResolveAppPathCommon(key, L"AppUserModelID", appPath)) {
+			appPath = appPath.substr(0, appPath.find(L"_"));
+			return true;
+		}
+		return false;
+	}
+	return true;
+
+}
+
+BOOL GetShellDefaultOpenWithProgPath(ExtensionString fileExt, ExtensionString &appPath)
+{
+	HKEY	extKey = NULL;
+	ExtensionString key;
+	BOOL	result = FALSE;
+	ULONG	regKey(REG_SZ);
+
+	if (fileExt[0] != '.')
+		fileExt = L"." + fileExt;
+
+	key = L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts\\" +  fileExt + L"\\UserChoice";
+
+	// Find out what program Explorer will open
+	if (::RegOpenKeyEx(HKEY_CURRENT_USER, key.c_str(), 0, KEY_QUERY_VALUE, &extKey) == ERROR_SUCCESS)
+	{
+		TCHAR editorPath[255];
+		ULONG fTypeSize = 255;
+
+		if (::RegQueryValueEx(extKey, L"Progid", NULL, &regKey, (LPBYTE)editorPath, &fTypeSize) == ERROR_SUCCESS)
+		{
+			result = ResolveAppPathFromProgID(editorPath, appPath);
+
+		}
+
+		::RegCloseKey(extKey);
+	}
+
+	return result;
+}
+
+/* static */
+BOOL GetLegacyWin32SystemEditor(ExtensionString fileExt, ExtensionString &appPath)
+{
+	HKEY	rootKey;
+	ULONG	regKey(REG_SZ);
+
+	if (fileExt[0] != '.')
+		fileExt = L"." + fileExt;
+
+	// find the key for the file extension
+	if (RegOpenKeyEx(HKEY_CLASSES_ROOT, fileExt.c_str(), 0, KEY_QUERY_VALUE, &rootKey) == ERROR_SUCCESS)
+	{
+		TCHAR nextKeyStr[255];
+		ULONG strSize = 255;
+		// get the value of the key
+		if (RegQueryValueEx(rootKey, L"", NULL, &regKey,
+			(LPBYTE)nextKeyStr, &strSize) == ERROR_SUCCESS)
+		{
+			return ResolveAppPathFromProgID(nextKeyStr, appPath);
+		}
+		RegCloseKey(rootKey);
+	}
+
+	fileExt = fileExt+ L"\\OpenWithProgids";
+	HKEY extKey;
+	// find the key for the file extension
+	if (RegOpenKeyEx(HKEY_CLASSES_ROOT, fileExt.c_str(), 0, KEY_QUERY_VALUE | KEY_READ | KEY_ENUMERATE_SUB_KEYS, &extKey) == ERROR_SUCCESS)
+	{
+		TCHAR subKeyStr[255];
+		ULONG subKeySize = 255;
+		DWORD index = 0;
+		LONG err = RegEnumValue(extKey, index, subKeyStr, &subKeySize,
+			0, 0, 0, NULL);
+		if (err != ERROR_NO_MORE_ITEMS)
+		{
+			return ResolveAppPathFromProgID(subKeyStr, appPath);
+			}
+		}
+		RegCloseKey(extKey);
+
+	return FALSE;
+}
+
+int32 getSystemDefaultApp(ExtensionString fileTypes, ExtensionString& fileTypesWithdefaultApp)
+{
+	wchar_t* nextPtr;
+	wchar_t delim[] = L",";
+	std::vector<ExtensionString> extArray;
+
+	wchar_t* token = std::wcstok((wchar_t*)fileTypes.c_str(), delim, &nextPtr);
+ 
+	while (token) {
+		extArray.push_back(token);
+		token = wcstok(NULL, delim, &nextPtr);
+	}
+
+	for (std::vector<ExtensionString>::iterator it = extArray.begin(); it != extArray.end(); ++it) {
+		ExtensionString appPath;
+		BOOL result = GetShellDefaultOpenWithProgPath(*it, appPath);
+
+		if (!result)
+			result = GetLegacyWin32SystemEditor(*it, appPath);
+
+		if (result)
+			fileTypesWithdefaultApp = fileTypesWithdefaultApp + *it + L":" + appPath + L",";
+	}
+
+	return true;
+
+}
+
 int32 OpenURLInDefaultBrowser(ExtensionString url)
 {
     DWORD result = (DWORD)ShellExecute(NULL, L"open", url.c_str(), NULL, NULL, SW_SHOWNORMAL);

--- a/appshell/appshell_extensions_win.cpp
+++ b/appshell/appshell_extensions_win.cpp
@@ -404,7 +404,7 @@ void CloseLiveBrowser(CefRefPtr<CefBrowser> browser, CefRefPtr<CefProcessMessage
 }
 
 
-static BOOL ResolveAppPathCommon(ExtensionString lpszKey, ExtensionString lpszVal, ExtensionString& appPath)
+static BOOL ResolveAppPathCommon(const ExtensionString& lpszKey, const ExtensionString& lpszVal, ExtensionString& appPath)
 {
     HKEY	keyRoot = NULL;
     BOOL	result = FALSE;
@@ -442,7 +442,7 @@ static BOOL ResolveAppPathCommon(ExtensionString lpszKey, ExtensionString lpszVa
 
 }
 
-static BOOL ResolveAppPathFromProgID(ExtensionString lpszProgID, ExtensionString& appPath)
+static BOOL ResolveAppPathFromProgID(const ExtensionString& lpszProgID, ExtensionString& appPath)
 {
 
     ExtensionString key;
@@ -462,7 +462,7 @@ static BOOL ResolveAppPathFromProgID(ExtensionString lpszProgID, ExtensionString
 
 }
 
-BOOL GetShellDefaultOpenWithProgPath(ExtensionString fileExt, ExtensionString &appPath)
+BOOL GetShellDefaultOpenWithProgPath(const ExtensionString& fileExt, ExtensionString &appPath)
 {
     HKEY	extKey = NULL;
     ExtensionString key;
@@ -492,7 +492,7 @@ BOOL GetShellDefaultOpenWithProgPath(ExtensionString fileExt, ExtensionString &a
 }
 
 
-BOOL GetLegacyWin32SystemEditor(ExtensionString fileExt, ExtensionString &appPath)
+BOOL GetLegacyWin32SystemEditor(const ExtensionString& fileExt, ExtensionString &appPath)
 {
     HKEY	rootKey;
     ULONG	regKey(REG_SZ);
@@ -517,7 +517,7 @@ BOOL GetLegacyWin32SystemEditor(ExtensionString fileExt, ExtensionString &appPat
     fileExt = fileExt+ L"\\OpenWithProgids";
     HKEY extKey;
     // find the key for the file extension
-    if (RegOpenKeyEx(HKEY_CLASSES_ROOT, fileExt.c_str(), 0, KEY_QUERY_VALUE | KEY_READ | KEY_ENUMERATE_SUB_KEYS, &extKey) == ERROR_SUCCESS)
+    if (RegOpenKeyEx(HKEY_CLASSES_ROOT, fileExt.c_str(), 0, KEY_QUERY_VALUE | KEY_READ, &extKey) == ERROR_SUCCESS)
     {
         TCHAR subKeyStr[255];
         ULONG subKeySize = 255;
@@ -527,14 +527,16 @@ BOOL GetLegacyWin32SystemEditor(ExtensionString fileExt, ExtensionString &appPat
         if (err != ERROR_NO_MORE_ITEMS)
         {
             return ResolveAppPathFromProgID(subKeyStr, appPath);
-            }
+
         }
+
         RegCloseKey(extKey);
+    }
 
     return FALSE;
 }
 
-int32 getSystemDefaultApp(ExtensionString fileTypes, ExtensionString& fileTypesWithdefaultApp)
+int32 getSystemDefaultApp(const ExtensionString& fileTypes, ExtensionString& fileTypesWithdefaultApp)
 {
     wchar_t* nextPtr;
     wchar_t delim[] = L",";
@@ -548,7 +550,7 @@ int32 getSystemDefaultApp(ExtensionString fileTypes, ExtensionString& fileTypesW
         token = wcstok(NULL, delim, &nextPtr);
     }
 
-    for (std::vector<ExtensionString>::iterator it = extArray.begin(); it != extArray.end(); ++it) {
+    for (std::vector<ExtensionString>::const_iterator it = extArray.begin(); it != extArray.end(); ++it) {
         ExtensionString appPath;
         BOOL result = GetShellDefaultOpenWithProgPath(*it, appPath);
 


### PR DESCRIPTION
API is added  to get Default Application for a file type.
Api Name: getSystemDefaultApp
This takes input as comma separated file extensions string and return comma separated OS Default Application for each extensions if any.

@swmitra @shubhsnov @sobisht @jha-g  @narayani28  please review