### PR TITLE
Wrong UserAgent for windows 10 as Compatibility Manifest were not getting applied in windows build

### DIFF
--- a/appshell.gyp
+++ b/appshell.gyp
@@ -116,6 +116,7 @@
             'VCManifestTool': {
               'AdditionalManifestFiles': [
                 'appshell.exe.manifest',
+                '>(win_exe_compatibility_manifest)',
               ],
             },
           },


### PR DESCRIPTION
Brackets windows version compatibility configuration are added in compatibility.manifest file,
but this compatibility configuration were not getting applied in build as this "compatibility.manifest" was not added in "AdditionalManifestFiles".

Added "compatibility.manifest" file in "AdditionalManifestFiles" , Now correct UserAgent string are coming for windows 10.

@narayani28 @jha-g please review.