### PR TITLE
Merge pull request #681 from niteskum/compatibilityManifestNotAppliedBug

### DIFF
--- a/appshell.gyp
+++ b/appshell.gyp
@@ -116,6 +116,7 @@
             'VCManifestTool': {
               'AdditionalManifestFiles': [
                 'appshell.exe.manifest',
+                '>(win_exe_compatibility_manifest)',
               ],
             },
           },


### PR DESCRIPTION
Wrong UserAgent for windows 10 as Compatibility Manifest were not getting applied in windows build
merging commit "477baba852efd1ef1885a0f536b7ba53d497a16c" from master to release-1.14.2 branch 