### PR TITLE
Higher Node.js version, that would be nice

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -329,7 +329,7 @@ module.exports = function (grunt) {
             "version"       : cef_version
         },
         "node": {
-            "version"       : "6.14.0"
+            "version"       : "14.8.0"
         },
         "icu": {
             "url"           : "http://s3.amazonaws.com/files.brackets.io/icu",


### PR DESCRIPTION
The low Node.js version is becoming problematic. Many npm packages (e.g. ESLint) require a higher Node.js version nowadays, at least version 8. For example, linting in projects with a locally installed ESLint is now often broken, because the local ESLint requires a higher Node version.
And I'm developing a large extension with Javascript debugging within Brackets, which I'll happily share with the community, but it won't work with Node v6.

So an upgrade would be nice ;-)  It requires testing ofcourse, I understand that. In my local installs on Windows and Linux I've manually replaced the Node executable with a higher version without a hitch.